### PR TITLE
Proper support for passing multiple files in one go on the command-line

### DIFF
--- a/lib/ClangToAst.ml
+++ b/lib/ClangToAst.ml
@@ -106,7 +106,6 @@ let lid_of_name name =
   match StringMap.find_opt name !name_map with
   | Some path -> Some (path, name)
   | None ->
-      if true then fatal_error "No entry for %s\n" name;
       None
 
 let translate_typ_name = function

--- a/out/hacl/src/bignum_base.rs
+++ b/out/hacl/src/bignum_base.rs
@@ -4,116 +4,70 @@
 #![allow(unused_assignments)]
 #![allow(unreachable_patterns)]
 
-pub fn Hacl_Bignum_Base_mul_wide_add2_u32(a: u32, b: u32, c_in: u32, out: &mut [u32]) -> u32
+pub fn Hacl_Bignum_Addition_bn_add_eq_len_u32(aLen: u32, a: &[u32], b: &[u32], res: &mut [u32]) ->
+    u32
 {
-  let out0: u32 = out[0usize];
-  let res: u64 =
-      (a as u64).wrapping_mul(b as u64).wrapping_add(c_in as u64).wrapping_add(out0 as u64);
-  out[0usize] = res as u32;
-  return res.wrapping_shr(32u32) as u32
-}
-
-pub fn Hacl_Bignum_Base_mul_wide_add2_u64(a: u64, b: u64, c_in: u64, out: &mut [u64]) -> u64
-{
-  let out0: u64 = out[0usize];
-  let res: crate::types::FStar_UInt128_uint128 =
-      crate::hacl_krmllib::FStar_UInt128_add(
-        crate::hacl_krmllib::FStar_UInt128_add(
-          crate::hacl_krmllib::FStar_UInt128_mul_wide(a, b),
-          crate::hacl_krmllib::FStar_UInt128_uint64_to_uint128(c_in)
-        ),
-        crate::hacl_krmllib::FStar_UInt128_uint64_to_uint128(out0)
-      );
-  out[0usize] = crate::hacl_krmllib::FStar_UInt128_uint128_to_uint64(res);
-  return
-  crate::hacl_krmllib::FStar_UInt128_uint128_to_uint64(
-    crate::hacl_krmllib::FStar_UInt128_shift_right(res, 64u32)
-  )
-}
-
-pub fn Hacl_Bignum_Convert_bn_from_bytes_be_uint64(len: u32, b: &[u8], res: &mut [u64])
-{
-  let bnLen: u32 = len.wrapping_sub(1u32).wrapping_div(8u32).wrapping_add(1u32);
-  let tmpLen: u32 = 8u32.wrapping_mul(bnLen);
-  let mut tmp: Box<[u8]> = vec![0u8; tmpLen as usize].into_boxed_slice();
-  ((&mut (&mut tmp)[tmpLen.wrapping_sub(len) as usize..])[0usize..len as usize]).copy_from_slice(
-    &b[0usize..len as usize]
-  );
-  for i in 0u32..bnLen
+  let mut c: u32 = 0u32;
+  for i in 0u32..aLen.wrapping_div(4u32)
   {
-    let u: u64 =
-        crate::lowstar_endianness::load64_be(
-          &(&tmp)[bnLen.wrapping_sub(i).wrapping_sub(1u32).wrapping_mul(8u32) as usize..]
-        );
-    let x: u64 = u;
-    let os: (&mut [u64], &mut [u64]) = res.split_at_mut(0usize);
-    os.1[i as usize] = x
-  }
-}
-
-pub fn Hacl_Bignum_Convert_bn_to_bytes_be_uint64(len: u32, b: &[u64], res: &mut [u8])
-{
-  let bnLen: u32 = len.wrapping_sub(1u32).wrapping_div(8u32).wrapping_add(1u32);
-  let tmpLen: u32 = 8u32.wrapping_mul(bnLen);
-  let mut tmp: Box<[u8]> = vec![0u8; tmpLen as usize].into_boxed_slice();
-  for i in 0u32..bnLen
-  {
-    crate::lowstar_endianness::store64_be(
-      &mut (&mut tmp)[i.wrapping_mul(8u32) as usize..],
-      b[bnLen.wrapping_sub(i).wrapping_sub(1u32) as usize]
-    )
+    let t1: u32 = a[4u32.wrapping_mul(i) as usize];
+    let t20: u32 = b[4u32.wrapping_mul(i) as usize];
+    let res_i0: (&mut [u32], &mut [u32]) = res.split_at_mut(4u32.wrapping_mul(i) as usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u32(c, t1, t20, res_i0.1);
+    let t10: u32 = a[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
+    let t21: u32 = b[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
+    let res_i1: (&mut [u32], &mut [u32]) = res_i0.1.split_at_mut(1usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u32(c, t10, t21, res_i1.1);
+    let t11: u32 = a[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
+    let t22: u32 = b[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
+    let res_i2: (&mut [u32], &mut [u32]) = res_i1.1.split_at_mut(1usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u32(c, t11, t22, res_i2.1);
+    let t12: u32 = a[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
+    let t2: u32 = b[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
+    let res_i: (&mut [u32], &mut [u32]) = res_i2.1.split_at_mut(1usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u32(c, t12, t2, res_i.1)
   };
-  (res[0usize..len as usize]).copy_from_slice(
-    &(&(&tmp)[tmpLen.wrapping_sub(len) as usize..])[0usize..len as usize]
-  )
-}
-
-pub fn Hacl_Bignum_Lib_bn_get_top_index_u32(len: u32, b: &[u32]) -> u32
-{
-  let mut r#priv: u32 = 0u32;
-  for i in 0u32..len
+  for i in aLen.wrapping_div(4u32).wrapping_mul(4u32)..aLen
   {
-    let mask: u32 = crate::hacl_krmllib::FStar_UInt32_eq_mask(b[i as usize], 0u32);
-    r#priv = mask & r#priv | ! mask & i
+    let t1: u32 = a[i as usize];
+    let t2: u32 = b[i as usize];
+    let res_i: (&mut [u32], &mut [u32]) = res.split_at_mut(i as usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u32(c, t1, t2, res_i.1)
   };
-  return r#priv
+  return c
 }
 
-pub fn Hacl_Bignum_Lib_bn_get_top_index_u64(len: u32, b: &[u64]) -> u64
+pub fn Hacl_Bignum_Addition_bn_add_eq_len_u64(aLen: u32, a: &[u64], b: &[u64], res: &mut [u64]) ->
+    u64
 {
-  let mut r#priv: u64 = 0u64;
-  for i in 0u32..len
+  let mut c: u64 = 0u64;
+  for i in 0u32..aLen.wrapping_div(4u32)
   {
-    let mask: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask(b[i as usize], 0u64);
-    r#priv = mask & r#priv | ! mask & i as u64
+    let t1: u64 = a[4u32.wrapping_mul(i) as usize];
+    let t20: u64 = b[4u32.wrapping_mul(i) as usize];
+    let res_i0: (&mut [u64], &mut [u64]) = res.split_at_mut(4u32.wrapping_mul(i) as usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t20, res_i0.1);
+    let t10: u64 = a[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
+    let t21: u64 = b[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
+    let res_i1: (&mut [u64], &mut [u64]) = res_i0.1.split_at_mut(1usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u64(c, t10, t21, res_i1.1);
+    let t11: u64 = a[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
+    let t22: u64 = b[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
+    let res_i2: (&mut [u64], &mut [u64]) = res_i1.1.split_at_mut(1usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u64(c, t11, t22, res_i2.1);
+    let t12: u64 = a[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
+    let t2: u64 = b[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
+    let res_i: (&mut [u64], &mut [u64]) = res_i2.1.split_at_mut(1usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i.1)
   };
-  return r#priv
-}
-
-pub fn Hacl_Bignum_Lib_bn_get_bits_u32(len: u32, b: &[u32], i: u32, l: u32) -> u32
-{
-  let i1: u32 = i.wrapping_div(32u32);
-  let j: u32 = i.wrapping_rem(32u32);
-  let p1: u32 = (b[i1 as usize]).wrapping_shr(j);
-  let mut ite: u32;
-  if i1.wrapping_add(1u32) < len && 0u32 < j
-  { ite = p1 | (b[i1.wrapping_add(1u32) as usize]).wrapping_shl(32u32.wrapping_sub(j)) }
-  else
-  { ite = p1 };
-  return ite & 1u32.wrapping_shl(l).wrapping_sub(1u32)
-}
-
-pub fn Hacl_Bignum_Lib_bn_get_bits_u64(len: u32, b: &[u64], i: u32, l: u32) -> u64
-{
-  let i1: u32 = i.wrapping_div(64u32);
-  let j: u32 = i.wrapping_rem(64u32);
-  let p1: u64 = (b[i1 as usize]).wrapping_shr(j);
-  let mut ite: u64;
-  if i1.wrapping_add(1u32) < len && 0u32 < j
-  { ite = p1 | (b[i1.wrapping_add(1u32) as usize]).wrapping_shl(64u32.wrapping_sub(j)) }
-  else
-  { ite = p1 };
-  return ite & 1u64.wrapping_shl(l).wrapping_sub(1u64)
+  for i in aLen.wrapping_div(4u32).wrapping_mul(4u32)..aLen
+  {
+    let t1: u64 = a[i as usize];
+    let t2: u64 = b[i as usize];
+    let res_i: (&mut [u64], &mut [u64]) = res.split_at_mut(i as usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t2, res_i.1)
+  };
+  return c
 }
 
 pub fn Hacl_Bignum_Addition_bn_sub_eq_len_u32(aLen: u32, a: &[u32], b: &[u32], res: &mut [u32]) ->
@@ -182,70 +136,116 @@ pub fn Hacl_Bignum_Addition_bn_sub_eq_len_u64(aLen: u32, a: &[u64], b: &[u64], r
   return c
 }
 
-pub fn Hacl_Bignum_Addition_bn_add_eq_len_u32(aLen: u32, a: &[u32], b: &[u32], res: &mut [u32]) ->
-    u32
+pub fn Hacl_Bignum_Base_mul_wide_add2_u32(a: u32, b: u32, c_in: u32, out: &mut [u32]) -> u32
 {
-  let mut c: u32 = 0u32;
-  for i in 0u32..aLen.wrapping_div(4u32)
-  {
-    let t1: u32 = a[4u32.wrapping_mul(i) as usize];
-    let t20: u32 = b[4u32.wrapping_mul(i) as usize];
-    let res_i0: (&mut [u32], &mut [u32]) = res.split_at_mut(4u32.wrapping_mul(i) as usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u32(c, t1, t20, res_i0.1);
-    let t10: u32 = a[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
-    let t21: u32 = b[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
-    let res_i1: (&mut [u32], &mut [u32]) = res_i0.1.split_at_mut(1usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u32(c, t10, t21, res_i1.1);
-    let t11: u32 = a[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
-    let t22: u32 = b[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
-    let res_i2: (&mut [u32], &mut [u32]) = res_i1.1.split_at_mut(1usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u32(c, t11, t22, res_i2.1);
-    let t12: u32 = a[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
-    let t2: u32 = b[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
-    let res_i: (&mut [u32], &mut [u32]) = res_i2.1.split_at_mut(1usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u32(c, t12, t2, res_i.1)
-  };
-  for i in aLen.wrapping_div(4u32).wrapping_mul(4u32)..aLen
-  {
-    let t1: u32 = a[i as usize];
-    let t2: u32 = b[i as usize];
-    let res_i: (&mut [u32], &mut [u32]) = res.split_at_mut(i as usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u32(c, t1, t2, res_i.1)
-  };
-  return c
+  let out0: u32 = out[0usize];
+  let res: u64 =
+      (a as u64).wrapping_mul(b as u64).wrapping_add(c_in as u64).wrapping_add(out0 as u64);
+  out[0usize] = res as u32;
+  return res.wrapping_shr(32u32) as u32
 }
 
-pub fn Hacl_Bignum_Addition_bn_add_eq_len_u64(aLen: u32, a: &[u64], b: &[u64], res: &mut [u64]) ->
-    u64
+pub fn Hacl_Bignum_Base_mul_wide_add2_u64(a: u64, b: u64, c_in: u64, out: &mut [u64]) -> u64
 {
-  let mut c: u64 = 0u64;
-  for i in 0u32..aLen.wrapping_div(4u32)
+  let out0: u64 = out[0usize];
+  let res: crate::types::FStar_UInt128_uint128 =
+      crate::hacl_krmllib::FStar_UInt128_add(
+        crate::hacl_krmllib::FStar_UInt128_add(
+          crate::hacl_krmllib::FStar_UInt128_mul_wide(a, b),
+          crate::hacl_krmllib::FStar_UInt128_uint64_to_uint128(c_in)
+        ),
+        crate::hacl_krmllib::FStar_UInt128_uint64_to_uint128(out0)
+      );
+  out[0usize] = crate::hacl_krmllib::FStar_UInt128_uint128_to_uint64(res);
+  return
+  crate::hacl_krmllib::FStar_UInt128_uint128_to_uint64(
+    crate::hacl_krmllib::FStar_UInt128_shift_right(res, 64u32)
+  )
+}
+
+pub fn Hacl_Bignum_Convert_bn_from_bytes_be_uint64(len: u32, b: &[u8], res: &mut [u64])
+{
+  let bnLen: u32 = len.wrapping_sub(1u32).wrapping_div(8u32).wrapping_add(1u32);
+  let tmpLen: u32 = 8u32.wrapping_mul(bnLen);
+  let mut tmp: Box<[u8]> = vec![0u8; tmpLen as usize].into_boxed_slice();
+  ((&mut (&mut tmp)[tmpLen.wrapping_sub(len) as usize..])[0usize..len as usize]).copy_from_slice(
+    &b[0usize..len as usize]
+  );
+  for i in 0u32..bnLen
   {
-    let t1: u64 = a[4u32.wrapping_mul(i) as usize];
-    let t20: u64 = b[4u32.wrapping_mul(i) as usize];
-    let res_i0: (&mut [u64], &mut [u64]) = res.split_at_mut(4u32.wrapping_mul(i) as usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t20, res_i0.1);
-    let t10: u64 = a[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
-    let t21: u64 = b[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
-    let res_i1: (&mut [u64], &mut [u64]) = res_i0.1.split_at_mut(1usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u64(c, t10, t21, res_i1.1);
-    let t11: u64 = a[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
-    let t22: u64 = b[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
-    let res_i2: (&mut [u64], &mut [u64]) = res_i1.1.split_at_mut(1usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u64(c, t11, t22, res_i2.1);
-    let t12: u64 = a[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
-    let t2: u64 = b[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
-    let res_i: (&mut [u64], &mut [u64]) = res_i2.1.split_at_mut(1usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i.1)
-  };
-  for i in aLen.wrapping_div(4u32).wrapping_mul(4u32)..aLen
+    let u: u64 =
+        crate::lowstar_endianness::load64_be(
+          &(&tmp)[bnLen.wrapping_sub(i).wrapping_sub(1u32).wrapping_mul(8u32) as usize..]
+        );
+    let x: u64 = u;
+    let os: (&mut [u64], &mut [u64]) = res.split_at_mut(0usize);
+    os.1[i as usize] = x
+  }
+}
+
+pub fn Hacl_Bignum_Convert_bn_to_bytes_be_uint64(len: u32, b: &[u64], res: &mut [u8])
+{
+  let bnLen: u32 = len.wrapping_sub(1u32).wrapping_div(8u32).wrapping_add(1u32);
+  let tmpLen: u32 = 8u32.wrapping_mul(bnLen);
+  let mut tmp: Box<[u8]> = vec![0u8; tmpLen as usize].into_boxed_slice();
+  for i in 0u32..bnLen
   {
-    let t1: u64 = a[i as usize];
-    let t2: u64 = b[i as usize];
-    let res_i: (&mut [u64], &mut [u64]) = res.split_at_mut(i as usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t2, res_i.1)
+    crate::lowstar_endianness::store64_be(
+      &mut (&mut tmp)[i.wrapping_mul(8u32) as usize..],
+      b[bnLen.wrapping_sub(i).wrapping_sub(1u32) as usize]
+    )
   };
-  return c
+  (res[0usize..len as usize]).copy_from_slice(
+    &(&(&tmp)[tmpLen.wrapping_sub(len) as usize..])[0usize..len as usize]
+  )
+}
+
+pub fn Hacl_Bignum_Lib_bn_get_bits_u32(len: u32, b: &[u32], i: u32, l: u32) -> u32
+{
+  let i1: u32 = i.wrapping_div(32u32);
+  let j: u32 = i.wrapping_rem(32u32);
+  let p1: u32 = (b[i1 as usize]).wrapping_shr(j);
+  let mut ite: u32;
+  if i1.wrapping_add(1u32) < len && 0u32 < j
+  { ite = p1 | (b[i1.wrapping_add(1u32) as usize]).wrapping_shl(32u32.wrapping_sub(j)) }
+  else
+  { ite = p1 };
+  return ite & 1u32.wrapping_shl(l).wrapping_sub(1u32)
+}
+
+pub fn Hacl_Bignum_Lib_bn_get_bits_u64(len: u32, b: &[u64], i: u32, l: u32) -> u64
+{
+  let i1: u32 = i.wrapping_div(64u32);
+  let j: u32 = i.wrapping_rem(64u32);
+  let p1: u64 = (b[i1 as usize]).wrapping_shr(j);
+  let mut ite: u64;
+  if i1.wrapping_add(1u32) < len && 0u32 < j
+  { ite = p1 | (b[i1.wrapping_add(1u32) as usize]).wrapping_shl(64u32.wrapping_sub(j)) }
+  else
+  { ite = p1 };
+  return ite & 1u64.wrapping_shl(l).wrapping_sub(1u64)
+}
+
+pub fn Hacl_Bignum_Lib_bn_get_top_index_u32(len: u32, b: &[u32]) -> u32
+{
+  let mut r#priv: u32 = 0u32;
+  for i in 0u32..len
+  {
+    let mask: u32 = crate::hacl_krmllib::FStar_UInt32_eq_mask(b[i as usize], 0u32);
+    r#priv = mask & r#priv | ! mask & i
+  };
+  return r#priv
+}
+
+pub fn Hacl_Bignum_Lib_bn_get_top_index_u64(len: u32, b: &[u64]) -> u64
+{
+  let mut r#priv: u64 = 0u64;
+  for i in 0u32..len
+  {
+    let mask: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask(b[i as usize], 0u64);
+    r#priv = mask & r#priv | ! mask & i as u64
+  };
+  return r#priv
 }
 
 pub fn Hacl_Bignum_Multiplication_bn_mul_u32(

--- a/out/hacl/src/chacha.rs
+++ b/out/hacl/src/chacha.rs
@@ -7,68 +7,6 @@
 pub const chacha20_constants: [u32; 4] =
     [1634760805u32, 857760878u32, 2036477234u32, 1797285236u32];
 
-pub fn quarter_round(st: &mut [u32], a: u32, b: u32, c: u32, d: u32)
-{
-  let sta: u32 = st[a as usize];
-  let stb0: u32 = st[b as usize];
-  let std0: u32 = st[d as usize];
-  let sta10: u32 = sta.wrapping_add(stb0);
-  let std10: u32 = std0 ^ sta10;
-  let std2: u32 = std10.wrapping_shl(16u32) | std10.wrapping_shr(16u32);
-  st[a as usize] = sta10;
-  st[d as usize] = std2;
-  let sta0: u32 = st[c as usize];
-  let stb1: u32 = st[d as usize];
-  let std3: u32 = st[b as usize];
-  let sta11: u32 = sta0.wrapping_add(stb1);
-  let std11: u32 = std3 ^ sta11;
-  let std20: u32 = std11.wrapping_shl(12u32) | std11.wrapping_shr(20u32);
-  st[c as usize] = sta11;
-  st[b as usize] = std20;
-  let sta2: u32 = st[a as usize];
-  let stb2: u32 = st[b as usize];
-  let std4: u32 = st[d as usize];
-  let sta12: u32 = sta2.wrapping_add(stb2);
-  let std12: u32 = std4 ^ sta12;
-  let std21: u32 = std12.wrapping_shl(8u32) | std12.wrapping_shr(24u32);
-  st[a as usize] = sta12;
-  st[d as usize] = std21;
-  let sta3: u32 = st[c as usize];
-  let stb: u32 = st[d as usize];
-  let std: u32 = st[b as usize];
-  let sta1: u32 = sta3.wrapping_add(stb);
-  let std1: u32 = std ^ sta1;
-  let std22: u32 = std1.wrapping_shl(7u32) | std1.wrapping_shr(25u32);
-  st[c as usize] = sta1;
-  st[b as usize] = std22
-}
-
-#[inline] pub fn double_round(st: &mut [u32])
-{
-  quarter_round(st, 0u32, 4u32, 8u32, 12u32);
-  quarter_round(st, 1u32, 5u32, 9u32, 13u32);
-  quarter_round(st, 2u32, 6u32, 10u32, 14u32);
-  quarter_round(st, 3u32, 7u32, 11u32, 15u32);
-  quarter_round(st, 0u32, 5u32, 10u32, 15u32);
-  quarter_round(st, 1u32, 6u32, 11u32, 12u32);
-  quarter_round(st, 2u32, 7u32, 8u32, 13u32);
-  quarter_round(st, 3u32, 4u32, 9u32, 14u32)
-}
-
-#[inline] pub fn rounds(st: &mut [u32])
-{
-  double_round(st);
-  double_round(st);
-  double_round(st);
-  double_round(st);
-  double_round(st);
-  double_round(st);
-  double_round(st);
-  double_round(st);
-  double_round(st);
-  double_round(st)
-}
-
 #[inline] pub fn chacha20_core(k: &mut [u32], ctx: &[u32], ctr: u32)
 {
   (k[0usize..16usize]).copy_from_slice(&ctx[0usize..16usize]);
@@ -84,35 +22,25 @@ pub fn quarter_round(st: &mut [u32], a: u32, b: u32, c: u32, d: u32)
   k[12usize] = (k[12usize]).wrapping_add(ctr_u32)
 }
 
-pub fn chacha20_init(ctx: &mut [u32], k: &[u8], n: &[u8], ctr: u32)
+pub fn chacha20_decrypt(
+  len: u32,
+  out: &mut [u8],
+  cipher: &[u8],
+  key: &[u8],
+  n: &[u8],
+  ctr: u32
+)
 {
-  for i in 0u32..4u32
-  {
-    let x: u32 = chacha20_constants[i as usize];
-    let os: (&mut [u32], &mut [u32]) = ctx.split_at_mut(0usize);
-    os.1[i as usize] = x
-  };
-  let uu____0: (&mut [u32], &mut [u32]) = ctx.split_at_mut(4usize);
-  for i in 0u32..8u32
-  {
-    let bj: (&[u8], &[u8]) = k.split_at(i.wrapping_mul(4u32) as usize);
-    let u: u32 = crate::lowstar_endianness::load32_le(bj.1);
-    let r: u32 = u;
-    let x: u32 = r;
-    let os: (&mut [u32], &mut [u32]) = uu____0.1.split_at_mut(0usize);
-    os.1[i as usize] = x
-  };
-  ctx[12usize] = ctr;
-  let uu____1: (&mut [u32], &mut [u32]) = ctx.split_at_mut(13usize);
-  for i in 0u32..3u32
-  {
-    let bj: (&[u8], &[u8]) = n.split_at(i.wrapping_mul(4u32) as usize);
-    let u: u32 = crate::lowstar_endianness::load32_le(bj.1);
-    let r: u32 = u;
-    let x: u32 = r;
-    let os: (&mut [u32], &mut [u32]) = uu____1.1.split_at_mut(0usize);
-    os.1[i as usize] = x
-  }
+  let mut ctx: [u32; 16] = [0u32; 16usize];
+  chacha20_init(&mut ctx, key, n, ctr);
+  chacha20_update(&ctx, len, out, cipher)
+}
+
+pub fn chacha20_encrypt(len: u32, out: &mut [u8], text: &[u8], key: &[u8], n: &[u8], ctr: u32)
+{
+  let mut ctx: [u32; 16] = [0u32; 16usize];
+  chacha20_init(&mut ctx, key, n, ctr);
+  chacha20_update(&ctx, len, out, text)
 }
 
 pub fn chacha20_encrypt_block(ctx: &[u32], out: &mut [u8], incr: u32, text: &[u8])
@@ -160,6 +88,37 @@ pub fn chacha20_encrypt_block(ctx: &[u32], out: &mut [u8], incr: u32, text: &[u8
   (out[0usize..len as usize]).copy_from_slice(&plain[0usize..len as usize])
 }
 
+pub fn chacha20_init(ctx: &mut [u32], k: &[u8], n: &[u8], ctr: u32)
+{
+  for i in 0u32..4u32
+  {
+    let x: u32 = chacha20_constants[i as usize];
+    let os: (&mut [u32], &mut [u32]) = ctx.split_at_mut(0usize);
+    os.1[i as usize] = x
+  };
+  let uu____0: (&mut [u32], &mut [u32]) = ctx.split_at_mut(4usize);
+  for i in 0u32..8u32
+  {
+    let bj: (&[u8], &[u8]) = k.split_at(i.wrapping_mul(4u32) as usize);
+    let u: u32 = crate::lowstar_endianness::load32_le(bj.1);
+    let r: u32 = u;
+    let x: u32 = r;
+    let os: (&mut [u32], &mut [u32]) = uu____0.1.split_at_mut(0usize);
+    os.1[i as usize] = x
+  };
+  ctx[12usize] = ctr;
+  let uu____1: (&mut [u32], &mut [u32]) = ctx.split_at_mut(13usize);
+  for i in 0u32..3u32
+  {
+    let bj: (&[u8], &[u8]) = n.split_at(i.wrapping_mul(4u32) as usize);
+    let u: u32 = crate::lowstar_endianness::load32_le(bj.1);
+    let r: u32 = u;
+    let x: u32 = r;
+    let os: (&mut [u32], &mut [u32]) = uu____1.1.split_at_mut(0usize);
+    os.1[i as usize] = x
+  }
+}
+
 pub fn chacha20_update(ctx: &[u32], len: u32, out: &mut [u8], text: &[u8])
 {
   let rem: u32 = len.wrapping_rem(64u32);
@@ -186,23 +145,64 @@ pub fn chacha20_update(ctx: &[u32], len: u32, out: &mut [u8], text: &[u8])
   }
 }
 
-pub fn chacha20_encrypt(len: u32, out: &mut [u8], text: &[u8], key: &[u8], n: &[u8], ctr: u32)
+#[inline] pub fn double_round(st: &mut [u32])
 {
-  let mut ctx: [u32; 16] = [0u32; 16usize];
-  chacha20_init(&mut ctx, key, n, ctr);
-  chacha20_update(&ctx, len, out, text)
+  quarter_round(st, 0u32, 4u32, 8u32, 12u32);
+  quarter_round(st, 1u32, 5u32, 9u32, 13u32);
+  quarter_round(st, 2u32, 6u32, 10u32, 14u32);
+  quarter_round(st, 3u32, 7u32, 11u32, 15u32);
+  quarter_round(st, 0u32, 5u32, 10u32, 15u32);
+  quarter_round(st, 1u32, 6u32, 11u32, 12u32);
+  quarter_round(st, 2u32, 7u32, 8u32, 13u32);
+  quarter_round(st, 3u32, 4u32, 9u32, 14u32)
 }
 
-pub fn chacha20_decrypt(
-  len: u32,
-  out: &mut [u8],
-  cipher: &[u8],
-  key: &[u8],
-  n: &[u8],
-  ctr: u32
-)
+pub fn quarter_round(st: &mut [u32], a: u32, b: u32, c: u32, d: u32)
 {
-  let mut ctx: [u32; 16] = [0u32; 16usize];
-  chacha20_init(&mut ctx, key, n, ctr);
-  chacha20_update(&ctx, len, out, cipher)
+  let sta: u32 = st[a as usize];
+  let stb0: u32 = st[b as usize];
+  let std0: u32 = st[d as usize];
+  let sta10: u32 = sta.wrapping_add(stb0);
+  let std10: u32 = std0 ^ sta10;
+  let std2: u32 = std10.wrapping_shl(16u32) | std10.wrapping_shr(16u32);
+  st[a as usize] = sta10;
+  st[d as usize] = std2;
+  let sta0: u32 = st[c as usize];
+  let stb1: u32 = st[d as usize];
+  let std3: u32 = st[b as usize];
+  let sta11: u32 = sta0.wrapping_add(stb1);
+  let std11: u32 = std3 ^ sta11;
+  let std20: u32 = std11.wrapping_shl(12u32) | std11.wrapping_shr(20u32);
+  st[c as usize] = sta11;
+  st[b as usize] = std20;
+  let sta2: u32 = st[a as usize];
+  let stb2: u32 = st[b as usize];
+  let std4: u32 = st[d as usize];
+  let sta12: u32 = sta2.wrapping_add(stb2);
+  let std12: u32 = std4 ^ sta12;
+  let std21: u32 = std12.wrapping_shl(8u32) | std12.wrapping_shr(24u32);
+  st[a as usize] = sta12;
+  st[d as usize] = std21;
+  let sta3: u32 = st[c as usize];
+  let stb: u32 = st[d as usize];
+  let std: u32 = st[b as usize];
+  let sta1: u32 = sta3.wrapping_add(stb);
+  let std1: u32 = std ^ sta1;
+  let std22: u32 = std1.wrapping_shl(7u32) | std1.wrapping_shr(25u32);
+  st[c as usize] = sta1;
+  st[b as usize] = std22
+}
+
+#[inline] pub fn rounds(st: &mut [u32])
+{
+  double_round(st);
+  double_round(st);
+  double_round(st);
+  double_round(st);
+  double_round(st);
+  double_round(st);
+  double_round(st);
+  double_round(st);
+  double_round(st);
+  double_round(st)
 }

--- a/out/hacl/src/hacl/bignum.rs
+++ b/out/hacl/src/hacl/bignum.rs
@@ -4,13 +4,929 @@
 #![allow(unused_assignments)]
 #![allow(unreachable_patterns)]
 
-#[derive(PartialEq, Clone)]
-pub struct Hacl_Bignum_MontArithmetic_bn_mont_ctx_u32
-{ pub len: u32, pub n: Box<[u32]>, pub mu: u32, pub r2: Box<[u32]> }
+pub fn Hacl_Bignum_AlmostMontgomery_bn_almost_mont_reduction_u32(
+  len: u32,
+  n: &[u32],
+  nInv: u32,
+  c: &mut [u32],
+  res: &mut [u32]
+)
+{
+  let mut c0: u32 = 0u32;
+  for i0 in 0u32..len
+  {
+    let qj: u32 = nInv.wrapping_mul(c[i0 as usize]);
+    let res_j0: (&mut [u32], &mut [u32]) = c.split_at_mut(i0 as usize);
+    let mut c1: u32 = 0u32;
+    for i in 0u32..len.wrapping_div(4u32)
+    {
+      let a_i: u32 = n[4u32.wrapping_mul(i) as usize];
+      let res_i0: (&mut [u32], &mut [u32]) = res_j0.1.split_at_mut(4u32.wrapping_mul(i) as usize);
+      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u32(a_i, qj, c1, res_i0.1);
+      let a_i0: u32 = n[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
+      let res_i1: (&mut [u32], &mut [u32]) = res_i0.1.split_at_mut(1usize);
+      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u32(a_i0, qj, c1, res_i1.1);
+      let a_i1: u32 = n[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
+      let res_i2: (&mut [u32], &mut [u32]) = res_i1.1.split_at_mut(1usize);
+      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u32(a_i1, qj, c1, res_i2.1);
+      let a_i2: u32 = n[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
+      let res_i: (&mut [u32], &mut [u32]) = res_i2.1.split_at_mut(1usize);
+      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, qj, c1, res_i.1)
+    };
+    for i in len.wrapping_div(4u32).wrapping_mul(4u32)..len
+    {
+      let a_i: u32 = n[i as usize];
+      let res_i: (&mut [u32], &mut [u32]) = res_j0.1.split_at_mut(i as usize);
+      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u32(a_i, qj, c1, res_i.1)
+    };
+    let r: u32 = c1;
+    let c10: u32 = r;
+    let res_j: u32 = c[len.wrapping_add(i0) as usize];
+    let resb: (&mut [u32], &mut [u32]) = c.split_at_mut(len.wrapping_add(i0) as usize);
+    c0 = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u32(c0, c10, res_j, resb.1)
+  };
+  (res[0usize..len.wrapping_add(len).wrapping_sub(len) as usize]).copy_from_slice(
+    &(&c[len as usize..])[0usize..len.wrapping_add(len).wrapping_sub(len) as usize]
+  );
+  let c00: u32 = c0;
+  let mut tmp: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+  let c1: u32 =
+      crate::hacl::bignum_base::Hacl_Bignum_Addition_bn_sub_eq_len_u32(len, res, n, &mut tmp);
+  crate::lowstar::ignore::ignore::<u32>(c1);
+  let m: u32 = 0u32.wrapping_sub(c00);
+  for i in 0u32..len
+  {
+    let x: u32 = m & (&tmp)[i as usize] | ! m & res[i as usize];
+    let os: (&mut [u32], &mut [u32]) = res.split_at_mut(0usize);
+    os.1[i as usize] = x
+  }
+}
 
-#[derive(PartialEq, Clone)]
-pub struct Hacl_Bignum_MontArithmetic_bn_mont_ctx_u64
-{ pub len: u32, pub n: Box<[u64]>, pub mu: u64, pub r2: Box<[u64]> }
+pub fn Hacl_Bignum_AlmostMontgomery_bn_almost_mont_reduction_u64(
+  len: u32,
+  n: &[u64],
+  nInv: u64,
+  c: &mut [u64],
+  res: &mut [u64]
+)
+{
+  let mut c0: u64 = 0u64;
+  for i0 in 0u32..len
+  {
+    let qj: u64 = nInv.wrapping_mul(c[i0 as usize]);
+    let res_j0: (&mut [u64], &mut [u64]) = c.split_at_mut(i0 as usize);
+    let mut c1: u64 = 0u64;
+    for i in 0u32..len.wrapping_div(4u32)
+    {
+      let a_i: u64 = n[4u32.wrapping_mul(i) as usize];
+      let res_i0: (&mut [u64], &mut [u64]) = res_j0.1.split_at_mut(4u32.wrapping_mul(i) as usize);
+      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c1, res_i0.1);
+      let a_i0: u64 = n[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
+      let res_i1: (&mut [u64], &mut [u64]) = res_i0.1.split_at_mut(1usize);
+      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, qj, c1, res_i1.1);
+      let a_i1: u64 = n[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
+      let res_i2: (&mut [u64], &mut [u64]) = res_i1.1.split_at_mut(1usize);
+      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, qj, c1, res_i2.1);
+      let a_i2: u64 = n[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
+      let res_i: (&mut [u64], &mut [u64]) = res_i2.1.split_at_mut(1usize);
+      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, qj, c1, res_i.1)
+    };
+    for i in len.wrapping_div(4u32).wrapping_mul(4u32)..len
+    {
+      let a_i: u64 = n[i as usize];
+      let res_i: (&mut [u64], &mut [u64]) = res_j0.1.split_at_mut(i as usize);
+      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c1, res_i.1)
+    };
+    let r: u64 = c1;
+    let c10: u64 = r;
+    let res_j: u64 = c[len.wrapping_add(i0) as usize];
+    let resb: (&mut [u64], &mut [u64]) = c.split_at_mut(len.wrapping_add(i0) as usize);
+    c0 = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u64(c0, c10, res_j, resb.1)
+  };
+  (res[0usize..len.wrapping_add(len).wrapping_sub(len) as usize]).copy_from_slice(
+    &(&c[len as usize..])[0usize..len.wrapping_add(len).wrapping_sub(len) as usize]
+  );
+  let c00: u64 = c0;
+  let mut tmp: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+  let c1: u64 =
+      crate::hacl::bignum_base::Hacl_Bignum_Addition_bn_sub_eq_len_u64(len, res, n, &mut tmp);
+  crate::lowstar::ignore::ignore::<u64>(c1);
+  let m: u64 = 0u64.wrapping_sub(c00);
+  for i in 0u32..len
+  {
+    let x: u64 = m & (&tmp)[i as usize] | ! m & res[i as usize];
+    let os: (&mut [u64], &mut [u64]) = res.split_at_mut(0usize);
+    os.1[i as usize] = x
+  }
+}
+
+pub fn Hacl_Bignum_Exponentiation_bn_check_mod_exp_u32(
+  len: u32,
+  n: &[u32],
+  a: &[u32],
+  bBits: u32,
+  b: &[u32]
+) ->
+    u32
+{
+  let mut one: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+  ((&mut one)[0usize..len as usize]).copy_from_slice(
+    &vec![0u32; len as usize].into_boxed_slice()
+  );
+  (&mut one)[0usize] = 1u32;
+  let bit0: u32 = n[0usize] & 1u32;
+  let m0: u32 = 0u32.wrapping_sub(bit0);
+  let mut acc0: u32 = 0u32;
+  for i in 0u32..len
+  {
+    let beq: u32 = crate::hacl_krmllib::FStar_UInt32_eq_mask((&one)[i as usize], n[i as usize]);
+    let blt: u32 = ! crate::hacl_krmllib::FStar_UInt32_gte_mask((&one)[i as usize], n[i as usize]);
+    acc0 = beq & acc0 | ! beq & blt
+  };
+  let m10: u32 = acc0;
+  let m00: u32 = m0 & m10;
+  let mut bLen: u32;
+  if bBits == 0u32
+  { bLen = 1u32 }
+  else
+  { bLen = bBits.wrapping_sub(1u32).wrapping_div(32u32).wrapping_add(1u32) };
+  let mut m1: u32;
+  if bBits < 32u32.wrapping_mul(bLen)
+  {
+    let mut b2: Box<[u32]> = vec![0u32; bLen as usize].into_boxed_slice();
+    let i0: u32 = bBits.wrapping_div(32u32);
+    let j: u32 = bBits.wrapping_rem(32u32);
+    (&mut b2)[i0 as usize] = (&b2)[i0 as usize] | 1u32.wrapping_shl(j);
+    let mut acc: u32 = 0u32;
+    for i in 0u32..bLen
+    {
+      let beq: u32 = crate::hacl_krmllib::FStar_UInt32_eq_mask(b[i as usize], (&b2)[i as usize]);
+      let blt: u32 = ! crate::hacl_krmllib::FStar_UInt32_gte_mask(b[i as usize], (&b2)[i as usize]);
+      acc = beq & acc | ! beq & blt
+    };
+    let res: u32 = acc;
+    m1 = res
+  }
+  else
+  { m1 = 4294967295u32 };
+  let mut acc: u32 = 0u32;
+  for i in 0u32..len
+  {
+    let beq: u32 = crate::hacl_krmllib::FStar_UInt32_eq_mask(a[i as usize], n[i as usize]);
+    let blt: u32 = ! crate::hacl_krmllib::FStar_UInt32_gte_mask(a[i as usize], n[i as usize]);
+    acc = beq & acc | ! beq & blt
+  };
+  let m2: u32 = acc;
+  let m: u32 = m1 & m2;
+  return m00 & m
+}
+
+pub fn Hacl_Bignum_Exponentiation_bn_check_mod_exp_u64(
+  len: u32,
+  n: &[u64],
+  a: &[u64],
+  bBits: u32,
+  b: &[u64]
+) ->
+    u64
+{
+  let mut one: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+  ((&mut one)[0usize..len as usize]).copy_from_slice(
+    &vec![0u64; len as usize].into_boxed_slice()
+  );
+  (&mut one)[0usize] = 1u64;
+  let bit0: u64 = n[0usize] & 1u64;
+  let m0: u64 = 0u64.wrapping_sub(bit0);
+  let mut acc0: u64 = 0u64;
+  for i in 0u32..len
+  {
+    let beq: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask((&one)[i as usize], n[i as usize]);
+    let blt: u64 = ! crate::hacl_krmllib::FStar_UInt64_gte_mask((&one)[i as usize], n[i as usize]);
+    acc0 = beq & acc0 | ! beq & blt
+  };
+  let m10: u64 = acc0;
+  let m00: u64 = m0 & m10;
+  let mut bLen: u32;
+  if bBits == 0u32
+  { bLen = 1u32 }
+  else
+  { bLen = bBits.wrapping_sub(1u32).wrapping_div(64u32).wrapping_add(1u32) };
+  let mut m1: u64;
+  if bBits < 64u32.wrapping_mul(bLen)
+  {
+    let mut b2: Box<[u64]> = vec![0u64; bLen as usize].into_boxed_slice();
+    let i0: u32 = bBits.wrapping_div(64u32);
+    let j: u32 = bBits.wrapping_rem(64u32);
+    (&mut b2)[i0 as usize] = (&b2)[i0 as usize] | 1u64.wrapping_shl(j);
+    let mut acc: u64 = 0u64;
+    for i in 0u32..bLen
+    {
+      let beq: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask(b[i as usize], (&b2)[i as usize]);
+      let blt: u64 = ! crate::hacl_krmllib::FStar_UInt64_gte_mask(b[i as usize], (&b2)[i as usize]);
+      acc = beq & acc | ! beq & blt
+    };
+    let res: u64 = acc;
+    m1 = res
+  }
+  else
+  { m1 = 18446744073709551615u64 };
+  let mut acc: u64 = 0u64;
+  for i in 0u32..len
+  {
+    let beq: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask(a[i as usize], n[i as usize]);
+    let blt: u64 = ! crate::hacl_krmllib::FStar_UInt64_gte_mask(a[i as usize], n[i as usize]);
+    acc = beq & acc | ! beq & blt
+  };
+  let m2: u64 = acc;
+  let m: u64 = m1 & m2;
+  return m00 & m
+}
+
+pub fn Hacl_Bignum_Exponentiation_bn_mod_exp_consttime_precomp_u32(
+  len: u32,
+  n: &[u32],
+  mu: u32,
+  r2: &[u32],
+  a: &[u32],
+  bBits: u32,
+  b: &[u32],
+  res: &mut [u32]
+)
+{
+  if bBits < 200u32
+  {
+    let mut aM: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+    Hacl_Bignum_Montgomery_bn_to_mont_u32(len, n, mu, r2, a, &mut aM);
+    let mut resM: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+    let mut ctx: Box<[u32]> = vec![0u32; len.wrapping_add(len) as usize].into_boxed_slice();
+    ((&mut ctx)[0usize..len as usize]).copy_from_slice(&n[0usize..len as usize]);
+    ((&mut (&mut ctx)[len as usize..])[0usize..len as usize]).copy_from_slice(
+      &r2[0usize..len as usize]
+    );
+    let mut sw: u32 = 0u32;
+    let ctx_n0: (&[u32], &[u32]) = ctx.split_at(0usize);
+    let ctx_r2: (&[u32], &[u32]) = ctx_n0.1.split_at(len as usize);
+    Hacl_Bignum_Montgomery_bn_from_mont_u32(len, ctx_r2.0, mu, ctx_r2.1, &mut resM);
+    crate::lowstar::ignore::ignore::<&[u32]>(&ctx);
+    for i0 in 0u32..bBits
+    {
+      let i1: u32 = bBits.wrapping_sub(i0).wrapping_sub(1u32).wrapping_div(32u32);
+      let j: u32 = bBits.wrapping_sub(i0).wrapping_sub(1u32).wrapping_rem(32u32);
+      let tmp: u32 = b[i1 as usize];
+      let bit: u32 = tmp.wrapping_shr(j) & 1u32;
+      let sw1: u32 = bit ^ sw;
+      for i in 0u32..len
+      {
+        let dummy: u32 = 0u32.wrapping_sub(sw1) & ((&resM)[i as usize] ^ (&aM)[i as usize]);
+        (&mut resM)[i as usize] = (&resM)[i as usize] ^ dummy;
+        (&mut aM)[i as usize] = (&aM)[i as usize] ^ dummy
+      };
+      let mut aM_copy: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+      ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&aM)[0usize..len as usize]);
+      let ctx_n1: (&[u32], &[u32]) = ctx.split_at(0usize);
+      bn_almost_mont_mul_u32(len, ctx_n1.1, mu, &aM_copy, &resM, &mut aM);
+      crate::lowstar::ignore::ignore::<&[u32]>(&ctx);
+      let mut aM_copy0: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+      ((&mut aM_copy0)[0usize..len as usize]).copy_from_slice(&(&resM)[0usize..len as usize]);
+      let ctx_n: (&[u32], &[u32]) = ctx.split_at(0usize);
+      bn_almost_mont_sqr_u32(len, ctx_n.1, mu, &aM_copy0, &mut resM);
+      crate::lowstar::ignore::ignore::<&[u32]>(&ctx);
+      sw = bit
+    };
+    let sw0: u32 = sw;
+    for i in 0u32..len
+    {
+      let dummy: u32 = 0u32.wrapping_sub(sw0) & ((&resM)[i as usize] ^ (&aM)[i as usize]);
+      (&mut resM)[i as usize] = (&resM)[i as usize] ^ dummy;
+      (&mut aM)[i as usize] = (&aM)[i as usize] ^ dummy
+    };
+    Hacl_Bignum_Montgomery_bn_from_mont_u32(len, n, mu, &resM, res);
+    return ()
+  };
+  let mut aM: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+  Hacl_Bignum_Montgomery_bn_to_mont_u32(len, n, mu, r2, a, &mut aM);
+  let mut resM: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+  let mut bLen: u32;
+  if bBits == 0u32
+  { bLen = 1u32 }
+  else
+  { bLen = bBits.wrapping_sub(1u32).wrapping_div(32u32).wrapping_add(1u32) };
+  let mut ctx: Box<[u32]> = vec![0u32; len.wrapping_add(len) as usize].into_boxed_slice();
+  ((&mut ctx)[0usize..len as usize]).copy_from_slice(&n[0usize..len as usize]);
+  ((&mut (&mut ctx)[len as usize..])[0usize..len as usize]).copy_from_slice(
+    &r2[0usize..len as usize]
+  );
+  let mut table: Box<[u32]> = vec![0u32; 16u32.wrapping_mul(len) as usize].into_boxed_slice();
+  let mut tmp: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+  let t0: (&mut [u32], &mut [u32]) = table.split_at_mut(0usize);
+  let t1: (&mut [u32], &mut [u32]) = t0.1.split_at_mut(len as usize);
+  let ctx_n0: (&[u32], &[u32]) = ctx.split_at(0usize);
+  let ctx_r20: (&[u32], &[u32]) = ctx_n0.1.split_at(len as usize);
+  Hacl_Bignum_Montgomery_bn_from_mont_u32(len, ctx_r20.0, mu, ctx_r20.1, t1.0);
+  crate::lowstar::ignore::ignore::<&[u32]>(&ctx);
+  (t1.1[0usize..len as usize]).copy_from_slice(&(&aM)[0usize..len as usize]);
+  crate::lowstar::ignore::ignore::<&[u32]>(&table);
+  for i in 0u32..7u32
+  {
+    let t11: (&[u32], &[u32]) = table.split_at(i.wrapping_add(1u32).wrapping_mul(len) as usize);
+    let mut aM_copy0: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+    ((&mut aM_copy0)[0usize..len as usize]).copy_from_slice(&t11.1[0usize..len as usize]);
+    let ctx_n1: (&[u32], &[u32]) = ctx.split_at(0usize);
+    bn_almost_mont_sqr_u32(len, ctx_n1.1, mu, &aM_copy0, &mut tmp);
+    crate::lowstar::ignore::ignore::<&[u32]>(&ctx);
+    ((&mut (&mut table)[2u32.wrapping_mul(i).wrapping_add(2u32).wrapping_mul(len) as usize..])[0usize..len
+    as
+    usize]).copy_from_slice(&(&tmp)[0usize..len as usize]);
+    let t2: (&[u32], &[u32]) =
+        table.split_at(2u32.wrapping_mul(i).wrapping_add(2u32).wrapping_mul(len) as usize);
+    let mut aM_copy: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+    ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&aM)[0usize..len as usize]);
+    let ctx_n: (&[u32], &[u32]) = ctx.split_at(0usize);
+    bn_almost_mont_mul_u32(len, ctx_n.1, mu, &aM_copy, t2.1, &mut tmp);
+    crate::lowstar::ignore::ignore::<&[u32]>(&ctx);
+    ((&mut (&mut table)[2u32.wrapping_mul(i).wrapping_add(3u32).wrapping_mul(len) as usize..])[0usize..len
+    as
+    usize]).copy_from_slice(&(&tmp)[0usize..len as usize])
+  };
+  if bBits.wrapping_rem(4u32) != 0u32
+  {
+    let i0: u32 = bBits.wrapping_div(4u32).wrapping_mul(4u32);
+    let bits_c: u32 = crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_bits_u32(bLen, b, i0, 4u32);
+    ((&mut resM)[0usize..len as usize]).copy_from_slice(
+      &(&(&table)[0u32.wrapping_mul(len) as usize..])[0usize..len as usize]
+    );
+    for i1 in 0u32..15u32
+    {
+      let c: u32 = crate::hacl_krmllib::FStar_UInt32_eq_mask(bits_c, i1.wrapping_add(1u32));
+      let res_j: (&[u32], &[u32]) =
+          table.split_at(i1.wrapping_add(1u32).wrapping_mul(len) as usize);
+      for i in 0u32..len
+      {
+        let x: u32 = c & res_j.1[i as usize] | ! c & (&resM)[i as usize];
+        let os: (&mut [u32], &mut [u32]) = resM.split_at_mut(0usize);
+        os.1[i as usize] = x
+      }
+    }
+  }
+  else
+  {
+    let ctx_n: (&[u32], &[u32]) = ctx.split_at(0usize);
+    let ctx_r2: (&[u32], &[u32]) = ctx_n.1.split_at(len as usize);
+    Hacl_Bignum_Montgomery_bn_from_mont_u32(len, ctx_r2.0, mu, ctx_r2.1, &mut resM);
+    crate::lowstar::ignore::ignore::<&[u32]>(&ctx)
+  };
+  let mut tmp0: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+  for i0 in 0u32..bBits.wrapping_div(4u32)
+  {
+    for i in 0u32..4u32
+    {
+      let mut aM_copy: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+      ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&resM)[0usize..len as usize]);
+      let ctx_n: (&[u32], &[u32]) = ctx.split_at(0usize);
+      bn_almost_mont_sqr_u32(len, ctx_n.1, mu, &aM_copy, &mut resM);
+      crate::lowstar::ignore::ignore::<&[u32]>(&ctx)
+    };
+    let k: u32 =
+        bBits.wrapping_sub(bBits.wrapping_rem(4u32)).wrapping_sub(4u32.wrapping_mul(i0)).wrapping_sub(
+          4u32
+        );
+    let bits_l: u32 = crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_bits_u32(bLen, b, k, 4u32);
+    crate::lowstar::ignore::ignore::<&[u32]>(&table);
+    ((&mut tmp0)[0usize..len as usize]).copy_from_slice(
+      &(&(&table)[0u32.wrapping_mul(len) as usize..])[0usize..len as usize]
+    );
+    for i1 in 0u32..15u32
+    {
+      let c: u32 = crate::hacl_krmllib::FStar_UInt32_eq_mask(bits_l, i1.wrapping_add(1u32));
+      let res_j: (&[u32], &[u32]) =
+          table.split_at(i1.wrapping_add(1u32).wrapping_mul(len) as usize);
+      for i in 0u32..len
+      {
+        let x: u32 = c & res_j.1[i as usize] | ! c & (&tmp0)[i as usize];
+        let os: (&mut [u32], &mut [u32]) = tmp0.split_at_mut(0usize);
+        os.1[i as usize] = x
+      }
+    };
+    let mut aM_copy: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+    ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&resM)[0usize..len as usize]);
+    let ctx_n: (&[u32], &[u32]) = ctx.split_at(0usize);
+    bn_almost_mont_mul_u32(len, ctx_n.1, mu, &aM_copy, &tmp0, &mut resM);
+    crate::lowstar::ignore::ignore::<&[u32]>(&ctx)
+  };
+  Hacl_Bignum_Montgomery_bn_from_mont_u32(len, n, mu, &resM, res)
+}
+
+pub fn Hacl_Bignum_Exponentiation_bn_mod_exp_consttime_precomp_u64(
+  len: u32,
+  n: &[u64],
+  mu: u64,
+  r2: &[u64],
+  a: &[u64],
+  bBits: u32,
+  b: &[u64],
+  res: &mut [u64]
+)
+{
+  if bBits < 200u32
+  {
+    let mut aM: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+    Hacl_Bignum_Montgomery_bn_to_mont_u64(len, n, mu, r2, a, &mut aM);
+    let mut resM: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+    let mut ctx: Box<[u64]> = vec![0u64; len.wrapping_add(len) as usize].into_boxed_slice();
+    ((&mut ctx)[0usize..len as usize]).copy_from_slice(&n[0usize..len as usize]);
+    ((&mut (&mut ctx)[len as usize..])[0usize..len as usize]).copy_from_slice(
+      &r2[0usize..len as usize]
+    );
+    let mut sw: u64 = 0u64;
+    let ctx_n0: (&[u64], &[u64]) = ctx.split_at(0usize);
+    let ctx_r2: (&[u64], &[u64]) = ctx_n0.1.split_at(len as usize);
+    Hacl_Bignum_Montgomery_bn_from_mont_u64(len, ctx_r2.0, mu, ctx_r2.1, &mut resM);
+    crate::lowstar::ignore::ignore::<&[u64]>(&ctx);
+    for i0 in 0u32..bBits
+    {
+      let i1: u32 = bBits.wrapping_sub(i0).wrapping_sub(1u32).wrapping_div(64u32);
+      let j: u32 = bBits.wrapping_sub(i0).wrapping_sub(1u32).wrapping_rem(64u32);
+      let tmp: u64 = b[i1 as usize];
+      let bit: u64 = tmp.wrapping_shr(j) & 1u64;
+      let sw1: u64 = bit ^ sw;
+      for i in 0u32..len
+      {
+        let dummy: u64 = 0u64.wrapping_sub(sw1) & ((&resM)[i as usize] ^ (&aM)[i as usize]);
+        (&mut resM)[i as usize] = (&resM)[i as usize] ^ dummy;
+        (&mut aM)[i as usize] = (&aM)[i as usize] ^ dummy
+      };
+      let mut aM_copy: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+      ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&aM)[0usize..len as usize]);
+      let ctx_n1: (&[u64], &[u64]) = ctx.split_at(0usize);
+      bn_almost_mont_mul_u64(len, ctx_n1.1, mu, &aM_copy, &resM, &mut aM);
+      crate::lowstar::ignore::ignore::<&[u64]>(&ctx);
+      let mut aM_copy0: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+      ((&mut aM_copy0)[0usize..len as usize]).copy_from_slice(&(&resM)[0usize..len as usize]);
+      let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
+      bn_almost_mont_sqr_u64(len, ctx_n.1, mu, &aM_copy0, &mut resM);
+      crate::lowstar::ignore::ignore::<&[u64]>(&ctx);
+      sw = bit
+    };
+    let sw0: u64 = sw;
+    for i in 0u32..len
+    {
+      let dummy: u64 = 0u64.wrapping_sub(sw0) & ((&resM)[i as usize] ^ (&aM)[i as usize]);
+      (&mut resM)[i as usize] = (&resM)[i as usize] ^ dummy;
+      (&mut aM)[i as usize] = (&aM)[i as usize] ^ dummy
+    };
+    Hacl_Bignum_Montgomery_bn_from_mont_u64(len, n, mu, &resM, res);
+    return ()
+  };
+  let mut aM: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+  Hacl_Bignum_Montgomery_bn_to_mont_u64(len, n, mu, r2, a, &mut aM);
+  let mut resM: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+  let mut bLen: u32;
+  if bBits == 0u32
+  { bLen = 1u32 }
+  else
+  { bLen = bBits.wrapping_sub(1u32).wrapping_div(64u32).wrapping_add(1u32) };
+  let mut ctx: Box<[u64]> = vec![0u64; len.wrapping_add(len) as usize].into_boxed_slice();
+  ((&mut ctx)[0usize..len as usize]).copy_from_slice(&n[0usize..len as usize]);
+  ((&mut (&mut ctx)[len as usize..])[0usize..len as usize]).copy_from_slice(
+    &r2[0usize..len as usize]
+  );
+  let mut table: Box<[u64]> = vec![0u64; 16u32.wrapping_mul(len) as usize].into_boxed_slice();
+  let mut tmp: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+  let t0: (&mut [u64], &mut [u64]) = table.split_at_mut(0usize);
+  let t1: (&mut [u64], &mut [u64]) = t0.1.split_at_mut(len as usize);
+  let ctx_n0: (&[u64], &[u64]) = ctx.split_at(0usize);
+  let ctx_r20: (&[u64], &[u64]) = ctx_n0.1.split_at(len as usize);
+  Hacl_Bignum_Montgomery_bn_from_mont_u64(len, ctx_r20.0, mu, ctx_r20.1, t1.0);
+  crate::lowstar::ignore::ignore::<&[u64]>(&ctx);
+  (t1.1[0usize..len as usize]).copy_from_slice(&(&aM)[0usize..len as usize]);
+  crate::lowstar::ignore::ignore::<&[u64]>(&table);
+  for i in 0u32..7u32
+  {
+    let t11: (&[u64], &[u64]) = table.split_at(i.wrapping_add(1u32).wrapping_mul(len) as usize);
+    let mut aM_copy0: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+    ((&mut aM_copy0)[0usize..len as usize]).copy_from_slice(&t11.1[0usize..len as usize]);
+    let ctx_n1: (&[u64], &[u64]) = ctx.split_at(0usize);
+    bn_almost_mont_sqr_u64(len, ctx_n1.1, mu, &aM_copy0, &mut tmp);
+    crate::lowstar::ignore::ignore::<&[u64]>(&ctx);
+    ((&mut (&mut table)[2u32.wrapping_mul(i).wrapping_add(2u32).wrapping_mul(len) as usize..])[0usize..len
+    as
+    usize]).copy_from_slice(&(&tmp)[0usize..len as usize]);
+    let t2: (&[u64], &[u64]) =
+        table.split_at(2u32.wrapping_mul(i).wrapping_add(2u32).wrapping_mul(len) as usize);
+    let mut aM_copy: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+    ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&aM)[0usize..len as usize]);
+    let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
+    bn_almost_mont_mul_u64(len, ctx_n.1, mu, &aM_copy, t2.1, &mut tmp);
+    crate::lowstar::ignore::ignore::<&[u64]>(&ctx);
+    ((&mut (&mut table)[2u32.wrapping_mul(i).wrapping_add(3u32).wrapping_mul(len) as usize..])[0usize..len
+    as
+    usize]).copy_from_slice(&(&tmp)[0usize..len as usize])
+  };
+  if bBits.wrapping_rem(4u32) != 0u32
+  {
+    let i0: u32 = bBits.wrapping_div(4u32).wrapping_mul(4u32);
+    let bits_c: u64 = crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_bits_u64(bLen, b, i0, 4u32);
+    ((&mut resM)[0usize..len as usize]).copy_from_slice(
+      &(&(&table)[0u32.wrapping_mul(len) as usize..])[0usize..len as usize]
+    );
+    for i1 in 0u32..15u32
+    {
+      let c: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask(bits_c, i1.wrapping_add(1u32) as u64);
+      let res_j: (&[u64], &[u64]) =
+          table.split_at(i1.wrapping_add(1u32).wrapping_mul(len) as usize);
+      for i in 0u32..len
+      {
+        let x: u64 = c & res_j.1[i as usize] | ! c & (&resM)[i as usize];
+        let os: (&mut [u64], &mut [u64]) = resM.split_at_mut(0usize);
+        os.1[i as usize] = x
+      }
+    }
+  }
+  else
+  {
+    let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
+    let ctx_r2: (&[u64], &[u64]) = ctx_n.1.split_at(len as usize);
+    Hacl_Bignum_Montgomery_bn_from_mont_u64(len, ctx_r2.0, mu, ctx_r2.1, &mut resM);
+    crate::lowstar::ignore::ignore::<&[u64]>(&ctx)
+  };
+  let mut tmp0: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+  for i0 in 0u32..bBits.wrapping_div(4u32)
+  {
+    for i in 0u32..4u32
+    {
+      let mut aM_copy: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+      ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&resM)[0usize..len as usize]);
+      let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
+      bn_almost_mont_sqr_u64(len, ctx_n.1, mu, &aM_copy, &mut resM);
+      crate::lowstar::ignore::ignore::<&[u64]>(&ctx)
+    };
+    let k: u32 =
+        bBits.wrapping_sub(bBits.wrapping_rem(4u32)).wrapping_sub(4u32.wrapping_mul(i0)).wrapping_sub(
+          4u32
+        );
+    let bits_l: u64 = crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_bits_u64(bLen, b, k, 4u32);
+    crate::lowstar::ignore::ignore::<&[u64]>(&table);
+    ((&mut tmp0)[0usize..len as usize]).copy_from_slice(
+      &(&(&table)[0u32.wrapping_mul(len) as usize..])[0usize..len as usize]
+    );
+    for i1 in 0u32..15u32
+    {
+      let c: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask(bits_l, i1.wrapping_add(1u32) as u64);
+      let res_j: (&[u64], &[u64]) =
+          table.split_at(i1.wrapping_add(1u32).wrapping_mul(len) as usize);
+      for i in 0u32..len
+      {
+        let x: u64 = c & res_j.1[i as usize] | ! c & (&tmp0)[i as usize];
+        let os: (&mut [u64], &mut [u64]) = tmp0.split_at_mut(0usize);
+        os.1[i as usize] = x
+      }
+    };
+    let mut aM_copy: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+    ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&resM)[0usize..len as usize]);
+    let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
+    bn_almost_mont_mul_u64(len, ctx_n.1, mu, &aM_copy, &tmp0, &mut resM);
+    crate::lowstar::ignore::ignore::<&[u64]>(&ctx)
+  };
+  Hacl_Bignum_Montgomery_bn_from_mont_u64(len, n, mu, &resM, res)
+}
+
+pub fn Hacl_Bignum_Exponentiation_bn_mod_exp_consttime_u32(
+  len: u32,
+  nBits: u32,
+  n: &[u32],
+  a: &[u32],
+  bBits: u32,
+  b: &[u32],
+  res: &mut [u32]
+)
+{
+  let mut r2: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+  Hacl_Bignum_Montgomery_bn_precomp_r2_mod_n_u32(len, nBits, n, &mut r2);
+  let mu: u32 = Hacl_Bignum_ModInvLimb_mod_inv_uint32(n[0usize]);
+  Hacl_Bignum_Exponentiation_bn_mod_exp_consttime_precomp_u32(len, n, mu, &r2, a, bBits, b, res)
+}
+
+pub fn Hacl_Bignum_Exponentiation_bn_mod_exp_consttime_u64(
+  len: u32,
+  nBits: u32,
+  n: &[u64],
+  a: &[u64],
+  bBits: u32,
+  b: &[u64],
+  res: &mut [u64]
+)
+{
+  let mut r2: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+  Hacl_Bignum_Montgomery_bn_precomp_r2_mod_n_u64(len, nBits, n, &mut r2);
+  let mu: u64 = Hacl_Bignum_ModInvLimb_mod_inv_uint64(n[0usize]);
+  Hacl_Bignum_Exponentiation_bn_mod_exp_consttime_precomp_u64(len, n, mu, &r2, a, bBits, b, res)
+}
+
+pub fn Hacl_Bignum_Exponentiation_bn_mod_exp_vartime_precomp_u32(
+  len: u32,
+  n: &[u32],
+  mu: u32,
+  r2: &[u32],
+  a: &[u32],
+  bBits: u32,
+  b: &[u32],
+  res: &mut [u32]
+)
+{
+  if bBits < 200u32
+  {
+    let mut aM: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+    Hacl_Bignum_Montgomery_bn_to_mont_u32(len, n, mu, r2, a, &mut aM);
+    let mut resM: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+    let mut ctx: Box<[u32]> = vec![0u32; len.wrapping_add(len) as usize].into_boxed_slice();
+    ((&mut ctx)[0usize..len as usize]).copy_from_slice(&n[0usize..len as usize]);
+    ((&mut (&mut ctx)[len as usize..])[0usize..len as usize]).copy_from_slice(
+      &r2[0usize..len as usize]
+    );
+    let ctx_n0: (&[u32], &[u32]) = ctx.split_at(0usize);
+    let ctx_r2: (&[u32], &[u32]) = ctx_n0.1.split_at(len as usize);
+    Hacl_Bignum_Montgomery_bn_from_mont_u32(len, ctx_r2.0, mu, ctx_r2.1, &mut resM);
+    crate::lowstar::ignore::ignore::<&[u32]>(&ctx);
+    for i in 0u32..bBits
+    {
+      let i1: u32 = i.wrapping_div(32u32);
+      let j: u32 = i.wrapping_rem(32u32);
+      let tmp: u32 = b[i1 as usize];
+      let bit: u32 = tmp.wrapping_shr(j) & 1u32;
+      if bit != 0u32
+      {
+        let mut aM_copy: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+        ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&resM)[0usize..len as usize]);
+        let ctx_n: (&[u32], &[u32]) = ctx.split_at(0usize);
+        bn_almost_mont_mul_u32(len, ctx_n.1, mu, &aM_copy, &aM, &mut resM);
+        crate::lowstar::ignore::ignore::<&[u32]>(&ctx)
+      };
+      let mut aM_copy: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+      ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&aM)[0usize..len as usize]);
+      let ctx_n: (&[u32], &[u32]) = ctx.split_at(0usize);
+      bn_almost_mont_sqr_u32(len, ctx_n.1, mu, &aM_copy, &mut aM);
+      crate::lowstar::ignore::ignore::<&[u32]>(&ctx)
+    };
+    Hacl_Bignum_Montgomery_bn_from_mont_u32(len, n, mu, &resM, res);
+    return ()
+  };
+  let mut aM: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+  Hacl_Bignum_Montgomery_bn_to_mont_u32(len, n, mu, r2, a, &mut aM);
+  let mut resM: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+  let mut bLen: u32;
+  if bBits == 0u32
+  { bLen = 1u32 }
+  else
+  { bLen = bBits.wrapping_sub(1u32).wrapping_div(32u32).wrapping_add(1u32) };
+  let mut ctx: Box<[u32]> = vec![0u32; len.wrapping_add(len) as usize].into_boxed_slice();
+  ((&mut ctx)[0usize..len as usize]).copy_from_slice(&n[0usize..len as usize]);
+  ((&mut (&mut ctx)[len as usize..])[0usize..len as usize]).copy_from_slice(
+    &r2[0usize..len as usize]
+  );
+  let mut table: Box<[u32]> = vec![0u32; 16u32.wrapping_mul(len) as usize].into_boxed_slice();
+  let mut tmp: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+  let t0: (&mut [u32], &mut [u32]) = table.split_at_mut(0usize);
+  let t1: (&mut [u32], &mut [u32]) = t0.1.split_at_mut(len as usize);
+  let ctx_n0: (&[u32], &[u32]) = ctx.split_at(0usize);
+  let ctx_r20: (&[u32], &[u32]) = ctx_n0.1.split_at(len as usize);
+  Hacl_Bignum_Montgomery_bn_from_mont_u32(len, ctx_r20.0, mu, ctx_r20.1, t1.0);
+  crate::lowstar::ignore::ignore::<&[u32]>(&ctx);
+  (t1.1[0usize..len as usize]).copy_from_slice(&(&aM)[0usize..len as usize]);
+  crate::lowstar::ignore::ignore::<&[u32]>(&table);
+  for i in 0u32..7u32
+  {
+    let t11: (&[u32], &[u32]) = table.split_at(i.wrapping_add(1u32).wrapping_mul(len) as usize);
+    let mut aM_copy0: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+    ((&mut aM_copy0)[0usize..len as usize]).copy_from_slice(&t11.1[0usize..len as usize]);
+    let ctx_n1: (&[u32], &[u32]) = ctx.split_at(0usize);
+    bn_almost_mont_sqr_u32(len, ctx_n1.1, mu, &aM_copy0, &mut tmp);
+    crate::lowstar::ignore::ignore::<&[u32]>(&ctx);
+    ((&mut (&mut table)[2u32.wrapping_mul(i).wrapping_add(2u32).wrapping_mul(len) as usize..])[0usize..len
+    as
+    usize]).copy_from_slice(&(&tmp)[0usize..len as usize]);
+    let t2: (&[u32], &[u32]) =
+        table.split_at(2u32.wrapping_mul(i).wrapping_add(2u32).wrapping_mul(len) as usize);
+    let mut aM_copy: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+    ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&aM)[0usize..len as usize]);
+    let ctx_n: (&[u32], &[u32]) = ctx.split_at(0usize);
+    bn_almost_mont_mul_u32(len, ctx_n.1, mu, &aM_copy, t2.1, &mut tmp);
+    crate::lowstar::ignore::ignore::<&[u32]>(&ctx);
+    ((&mut (&mut table)[2u32.wrapping_mul(i).wrapping_add(3u32).wrapping_mul(len) as usize..])[0usize..len
+    as
+    usize]).copy_from_slice(&(&tmp)[0usize..len as usize])
+  };
+  if bBits.wrapping_rem(4u32) != 0u32
+  {
+    let i: u32 = bBits.wrapping_div(4u32).wrapping_mul(4u32);
+    let bits_c: u32 = crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_bits_u32(bLen, b, i, 4u32);
+    let bits_l32: u32 = bits_c;
+    let a_bits_l: (&[u32], &[u32]) = table.split_at(bits_l32.wrapping_mul(len) as usize);
+    ((&mut resM)[0usize..len as usize]).copy_from_slice(&a_bits_l.1[0usize..len as usize])
+  }
+  else
+  {
+    let ctx_n: (&[u32], &[u32]) = ctx.split_at(0usize);
+    let ctx_r2: (&[u32], &[u32]) = ctx_n.1.split_at(len as usize);
+    Hacl_Bignum_Montgomery_bn_from_mont_u32(len, ctx_r2.0, mu, ctx_r2.1, &mut resM);
+    crate::lowstar::ignore::ignore::<&[u32]>(&ctx)
+  };
+  let mut tmp0: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+  for i in 0u32..bBits.wrapping_div(4u32)
+  {
+    for i0 in 0u32..4u32
+    {
+      let mut aM_copy: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+      ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&resM)[0usize..len as usize]);
+      let ctx_n: (&[u32], &[u32]) = ctx.split_at(0usize);
+      bn_almost_mont_sqr_u32(len, ctx_n.1, mu, &aM_copy, &mut resM);
+      crate::lowstar::ignore::ignore::<&[u32]>(&ctx)
+    };
+    let k: u32 =
+        bBits.wrapping_sub(bBits.wrapping_rem(4u32)).wrapping_sub(4u32.wrapping_mul(i)).wrapping_sub(
+          4u32
+        );
+    let bits_l: u32 = crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_bits_u32(bLen, b, k, 4u32);
+    crate::lowstar::ignore::ignore::<&[u32]>(&table);
+    let bits_l32: u32 = bits_l;
+    let a_bits_l: (&[u32], &[u32]) = table.split_at(bits_l32.wrapping_mul(len) as usize);
+    ((&mut tmp0)[0usize..len as usize]).copy_from_slice(&a_bits_l.1[0usize..len as usize]);
+    let mut aM_copy: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+    ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&resM)[0usize..len as usize]);
+    let ctx_n: (&[u32], &[u32]) = ctx.split_at(0usize);
+    bn_almost_mont_mul_u32(len, ctx_n.1, mu, &aM_copy, &tmp0, &mut resM);
+    crate::lowstar::ignore::ignore::<&[u32]>(&ctx)
+  };
+  Hacl_Bignum_Montgomery_bn_from_mont_u32(len, n, mu, &resM, res)
+}
+
+pub fn Hacl_Bignum_Exponentiation_bn_mod_exp_vartime_precomp_u64(
+  len: u32,
+  n: &[u64],
+  mu: u64,
+  r2: &[u64],
+  a: &[u64],
+  bBits: u32,
+  b: &[u64],
+  res: &mut [u64]
+)
+{
+  if bBits < 200u32
+  {
+    let mut aM: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+    Hacl_Bignum_Montgomery_bn_to_mont_u64(len, n, mu, r2, a, &mut aM);
+    let mut resM: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+    let mut ctx: Box<[u64]> = vec![0u64; len.wrapping_add(len) as usize].into_boxed_slice();
+    ((&mut ctx)[0usize..len as usize]).copy_from_slice(&n[0usize..len as usize]);
+    ((&mut (&mut ctx)[len as usize..])[0usize..len as usize]).copy_from_slice(
+      &r2[0usize..len as usize]
+    );
+    let ctx_n0: (&[u64], &[u64]) = ctx.split_at(0usize);
+    let ctx_r2: (&[u64], &[u64]) = ctx_n0.1.split_at(len as usize);
+    Hacl_Bignum_Montgomery_bn_from_mont_u64(len, ctx_r2.0, mu, ctx_r2.1, &mut resM);
+    crate::lowstar::ignore::ignore::<&[u64]>(&ctx);
+    for i in 0u32..bBits
+    {
+      let i1: u32 = i.wrapping_div(64u32);
+      let j: u32 = i.wrapping_rem(64u32);
+      let tmp: u64 = b[i1 as usize];
+      let bit: u64 = tmp.wrapping_shr(j) & 1u64;
+      if bit != 0u64
+      {
+        let mut aM_copy: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+        ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&resM)[0usize..len as usize]);
+        let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
+        bn_almost_mont_mul_u64(len, ctx_n.1, mu, &aM_copy, &aM, &mut resM);
+        crate::lowstar::ignore::ignore::<&[u64]>(&ctx)
+      };
+      let mut aM_copy: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+      ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&aM)[0usize..len as usize]);
+      let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
+      bn_almost_mont_sqr_u64(len, ctx_n.1, mu, &aM_copy, &mut aM);
+      crate::lowstar::ignore::ignore::<&[u64]>(&ctx)
+    };
+    Hacl_Bignum_Montgomery_bn_from_mont_u64(len, n, mu, &resM, res);
+    return ()
+  };
+  let mut aM: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+  Hacl_Bignum_Montgomery_bn_to_mont_u64(len, n, mu, r2, a, &mut aM);
+  let mut resM: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+  let mut bLen: u32;
+  if bBits == 0u32
+  { bLen = 1u32 }
+  else
+  { bLen = bBits.wrapping_sub(1u32).wrapping_div(64u32).wrapping_add(1u32) };
+  let mut ctx: Box<[u64]> = vec![0u64; len.wrapping_add(len) as usize].into_boxed_slice();
+  ((&mut ctx)[0usize..len as usize]).copy_from_slice(&n[0usize..len as usize]);
+  ((&mut (&mut ctx)[len as usize..])[0usize..len as usize]).copy_from_slice(
+    &r2[0usize..len as usize]
+  );
+  let mut table: Box<[u64]> = vec![0u64; 16u32.wrapping_mul(len) as usize].into_boxed_slice();
+  let mut tmp: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+  let t0: (&mut [u64], &mut [u64]) = table.split_at_mut(0usize);
+  let t1: (&mut [u64], &mut [u64]) = t0.1.split_at_mut(len as usize);
+  let ctx_n0: (&[u64], &[u64]) = ctx.split_at(0usize);
+  let ctx_r20: (&[u64], &[u64]) = ctx_n0.1.split_at(len as usize);
+  Hacl_Bignum_Montgomery_bn_from_mont_u64(len, ctx_r20.0, mu, ctx_r20.1, t1.0);
+  crate::lowstar::ignore::ignore::<&[u64]>(&ctx);
+  (t1.1[0usize..len as usize]).copy_from_slice(&(&aM)[0usize..len as usize]);
+  crate::lowstar::ignore::ignore::<&[u64]>(&table);
+  for i in 0u32..7u32
+  {
+    let t11: (&[u64], &[u64]) = table.split_at(i.wrapping_add(1u32).wrapping_mul(len) as usize);
+    let mut aM_copy0: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+    ((&mut aM_copy0)[0usize..len as usize]).copy_from_slice(&t11.1[0usize..len as usize]);
+    let ctx_n1: (&[u64], &[u64]) = ctx.split_at(0usize);
+    bn_almost_mont_sqr_u64(len, ctx_n1.1, mu, &aM_copy0, &mut tmp);
+    crate::lowstar::ignore::ignore::<&[u64]>(&ctx);
+    ((&mut (&mut table)[2u32.wrapping_mul(i).wrapping_add(2u32).wrapping_mul(len) as usize..])[0usize..len
+    as
+    usize]).copy_from_slice(&(&tmp)[0usize..len as usize]);
+    let t2: (&[u64], &[u64]) =
+        table.split_at(2u32.wrapping_mul(i).wrapping_add(2u32).wrapping_mul(len) as usize);
+    let mut aM_copy: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+    ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&aM)[0usize..len as usize]);
+    let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
+    bn_almost_mont_mul_u64(len, ctx_n.1, mu, &aM_copy, t2.1, &mut tmp);
+    crate::lowstar::ignore::ignore::<&[u64]>(&ctx);
+    ((&mut (&mut table)[2u32.wrapping_mul(i).wrapping_add(3u32).wrapping_mul(len) as usize..])[0usize..len
+    as
+    usize]).copy_from_slice(&(&tmp)[0usize..len as usize])
+  };
+  if bBits.wrapping_rem(4u32) != 0u32
+  {
+    let i: u32 = bBits.wrapping_div(4u32).wrapping_mul(4u32);
+    let bits_c: u64 = crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_bits_u64(bLen, b, i, 4u32);
+    let bits_l32: u32 = bits_c as u32;
+    let a_bits_l: (&[u64], &[u64]) = table.split_at(bits_l32.wrapping_mul(len) as usize);
+    ((&mut resM)[0usize..len as usize]).copy_from_slice(&a_bits_l.1[0usize..len as usize])
+  }
+  else
+  {
+    let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
+    let ctx_r2: (&[u64], &[u64]) = ctx_n.1.split_at(len as usize);
+    Hacl_Bignum_Montgomery_bn_from_mont_u64(len, ctx_r2.0, mu, ctx_r2.1, &mut resM);
+    crate::lowstar::ignore::ignore::<&[u64]>(&ctx)
+  };
+  let mut tmp0: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+  for i in 0u32..bBits.wrapping_div(4u32)
+  {
+    for i0 in 0u32..4u32
+    {
+      let mut aM_copy: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+      ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&resM)[0usize..len as usize]);
+      let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
+      bn_almost_mont_sqr_u64(len, ctx_n.1, mu, &aM_copy, &mut resM);
+      crate::lowstar::ignore::ignore::<&[u64]>(&ctx)
+    };
+    let k: u32 =
+        bBits.wrapping_sub(bBits.wrapping_rem(4u32)).wrapping_sub(4u32.wrapping_mul(i)).wrapping_sub(
+          4u32
+        );
+    let bits_l: u64 = crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_bits_u64(bLen, b, k, 4u32);
+    crate::lowstar::ignore::ignore::<&[u64]>(&table);
+    let bits_l32: u32 = bits_l as u32;
+    let a_bits_l: (&[u64], &[u64]) = table.split_at(bits_l32.wrapping_mul(len) as usize);
+    ((&mut tmp0)[0usize..len as usize]).copy_from_slice(&a_bits_l.1[0usize..len as usize]);
+    let mut aM_copy: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+    ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&resM)[0usize..len as usize]);
+    let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
+    bn_almost_mont_mul_u64(len, ctx_n.1, mu, &aM_copy, &tmp0, &mut resM);
+    crate::lowstar::ignore::ignore::<&[u64]>(&ctx)
+  };
+  Hacl_Bignum_Montgomery_bn_from_mont_u64(len, n, mu, &resM, res)
+}
+
+pub fn Hacl_Bignum_Exponentiation_bn_mod_exp_vartime_u32(
+  len: u32,
+  nBits: u32,
+  n: &[u32],
+  a: &[u32],
+  bBits: u32,
+  b: &[u32],
+  res: &mut [u32]
+)
+{
+  let mut r2: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+  Hacl_Bignum_Montgomery_bn_precomp_r2_mod_n_u32(len, nBits, n, &mut r2);
+  let mu: u32 = Hacl_Bignum_ModInvLimb_mod_inv_uint32(n[0usize]);
+  Hacl_Bignum_Exponentiation_bn_mod_exp_vartime_precomp_u32(len, n, mu, &r2, a, bBits, b, res)
+}
+
+pub fn Hacl_Bignum_Exponentiation_bn_mod_exp_vartime_u64(
+  len: u32,
+  nBits: u32,
+  n: &[u64],
+  a: &[u64],
+  bBits: u32,
+  b: &[u64],
+  res: &mut [u64]
+)
+{
+  let mut r2: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+  Hacl_Bignum_Montgomery_bn_precomp_r2_mod_n_u64(len, nBits, n, &mut r2);
+  let mu: u64 = Hacl_Bignum_ModInvLimb_mod_inv_uint64(n[0usize]);
+  Hacl_Bignum_Exponentiation_bn_mod_exp_vartime_precomp_u64(len, n, mu, &r2, a, bBits, b, res)
+}
 
 pub fn Hacl_Bignum_Karatsuba_bn_karatsuba_mul_uint32(
   aLen: u32,
@@ -560,6 +1476,252 @@ pub fn Hacl_Bignum_Karatsuba_bn_karatsuba_sqr_uint64(
   crate::lowstar::ignore::ignore::<u64>(c9)
 }
 
+pub fn Hacl_Bignum_ModInvLimb_mod_inv_uint32(n0: u32) -> u32
+{
+  let alpha: u32 = 2147483648u32;
+  let beta: u32 = n0;
+  let mut ub: u32 = 0u32;
+  let mut vb: u32 = 0u32;
+  ub = 1u32;
+  vb = 0u32;
+  for i in 0u32..32u32
+  {
+    let us: u32 = ub;
+    let vs: u32 = vb;
+    let u_is_odd: u32 = 0u32.wrapping_sub(us & 1u32);
+    let beta_if_u_is_odd: u32 = beta & u_is_odd;
+    ub = (us ^ beta_if_u_is_odd).wrapping_shr(1u32).wrapping_add(us & beta_if_u_is_odd);
+    let alpha_if_u_is_odd: u32 = alpha & u_is_odd;
+    vb = vs.wrapping_shr(1u32).wrapping_add(alpha_if_u_is_odd)
+  };
+  return vb
+}
+
+pub fn Hacl_Bignum_ModInvLimb_mod_inv_uint64(n0: u64) -> u64
+{
+  let alpha: u64 = 9223372036854775808u64;
+  let beta: u64 = n0;
+  let mut ub: u64 = 0u64;
+  let mut vb: u64 = 0u64;
+  ub = 1u64;
+  vb = 0u64;
+  for i in 0u32..64u32
+  {
+    let us: u64 = ub;
+    let vs: u64 = vb;
+    let u_is_odd: u64 = 0u64.wrapping_sub(us & 1u64);
+    let beta_if_u_is_odd: u64 = beta & u_is_odd;
+    ub = (us ^ beta_if_u_is_odd).wrapping_shr(1u32).wrapping_add(us & beta_if_u_is_odd);
+    let alpha_if_u_is_odd: u64 = alpha & u_is_odd;
+    vb = vs.wrapping_shr(1u32).wrapping_add(alpha_if_u_is_odd)
+  };
+  return vb
+}
+
+#[derive(PartialEq, Clone)]
+pub struct Hacl_Bignum_MontArithmetic_bn_mont_ctx_u32
+{ pub len: u32, pub n: Box<[u32]>, pub mu: u32, pub r2: Box<[u32]> }
+
+#[derive(PartialEq, Clone)]
+pub struct Hacl_Bignum_MontArithmetic_bn_mont_ctx_u64
+{ pub len: u32, pub n: Box<[u64]>, pub mu: u64, pub r2: Box<[u64]> }
+
+pub fn Hacl_Bignum_Montgomery_bn_check_modulus_u32(len: u32, n: &[u32]) -> u32
+{
+  let mut one: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+  ((&mut one)[0usize..len as usize]).copy_from_slice(
+    &vec![0u32; len as usize].into_boxed_slice()
+  );
+  (&mut one)[0usize] = 1u32;
+  let bit0: u32 = n[0usize] & 1u32;
+  let m0: u32 = 0u32.wrapping_sub(bit0);
+  let mut acc: u32 = 0u32;
+  for i in 0u32..len
+  {
+    let beq: u32 = crate::hacl_krmllib::FStar_UInt32_eq_mask((&one)[i as usize], n[i as usize]);
+    let blt: u32 = ! crate::hacl_krmllib::FStar_UInt32_gte_mask((&one)[i as usize], n[i as usize]);
+    acc = beq & acc | ! beq & blt
+  };
+  let m1: u32 = acc;
+  return m0 & m1
+}
+
+pub fn Hacl_Bignum_Montgomery_bn_check_modulus_u64(len: u32, n: &[u64]) -> u64
+{
+  let mut one: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+  ((&mut one)[0usize..len as usize]).copy_from_slice(
+    &vec![0u64; len as usize].into_boxed_slice()
+  );
+  (&mut one)[0usize] = 1u64;
+  let bit0: u64 = n[0usize] & 1u64;
+  let m0: u64 = 0u64.wrapping_sub(bit0);
+  let mut acc: u64 = 0u64;
+  for i in 0u32..len
+  {
+    let beq: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask((&one)[i as usize], n[i as usize]);
+    let blt: u64 = ! crate::hacl_krmllib::FStar_UInt64_gte_mask((&one)[i as usize], n[i as usize]);
+    acc = beq & acc | ! beq & blt
+  };
+  let m1: u64 = acc;
+  return m0 & m1
+}
+
+pub fn Hacl_Bignum_Montgomery_bn_from_mont_u32(
+  len: u32,
+  n: &[u32],
+  nInv_u64: u32,
+  aM: &[u32],
+  a: &mut [u32]
+)
+{
+  let mut tmp: Box<[u32]> = vec![0u32; len.wrapping_add(len) as usize].into_boxed_slice();
+  ((&mut tmp)[0usize..len as usize]).copy_from_slice(&aM[0usize..len as usize]);
+  bn_mont_reduction_u32(len, n, nInv_u64, &mut tmp, a)
+}
+
+pub fn Hacl_Bignum_Montgomery_bn_from_mont_u64(
+  len: u32,
+  n: &[u64],
+  nInv_u64: u64,
+  aM: &[u64],
+  a: &mut [u64]
+)
+{
+  let mut tmp: Box<[u64]> = vec![0u64; len.wrapping_add(len) as usize].into_boxed_slice();
+  ((&mut tmp)[0usize..len as usize]).copy_from_slice(&aM[0usize..len as usize]);
+  bn_mont_reduction_u64(len, n, nInv_u64, &mut tmp, a)
+}
+
+pub fn Hacl_Bignum_Montgomery_bn_mont_mul_u32(
+  len: u32,
+  n: &[u32],
+  nInv_u64: u32,
+  aM: &[u32],
+  bM: &[u32],
+  resM: &mut [u32]
+)
+{
+  let mut c: Box<[u32]> = vec![0u32; len.wrapping_add(len) as usize].into_boxed_slice();
+  let mut tmp: Box<[u32]> = vec![0u32; 4u32.wrapping_mul(len) as usize].into_boxed_slice();
+  Hacl_Bignum_Karatsuba_bn_karatsuba_mul_uint32(len, aM, bM, &mut tmp, &mut c);
+  bn_mont_reduction_u32(len, n, nInv_u64, &mut c, resM)
+}
+
+pub fn Hacl_Bignum_Montgomery_bn_mont_mul_u64(
+  len: u32,
+  n: &[u64],
+  nInv_u64: u64,
+  aM: &[u64],
+  bM: &[u64],
+  resM: &mut [u64]
+)
+{
+  let mut c: Box<[u64]> = vec![0u64; len.wrapping_add(len) as usize].into_boxed_slice();
+  let mut tmp: Box<[u64]> = vec![0u64; 4u32.wrapping_mul(len) as usize].into_boxed_slice();
+  Hacl_Bignum_Karatsuba_bn_karatsuba_mul_uint64(len, aM, bM, &mut tmp, &mut c);
+  bn_mont_reduction_u64(len, n, nInv_u64, &mut c, resM)
+}
+
+pub fn Hacl_Bignum_Montgomery_bn_mont_sqr_u32(
+  len: u32,
+  n: &[u32],
+  nInv_u64: u32,
+  aM: &[u32],
+  resM: &mut [u32]
+)
+{
+  let mut c: Box<[u32]> = vec![0u32; len.wrapping_add(len) as usize].into_boxed_slice();
+  let mut tmp: Box<[u32]> = vec![0u32; 4u32.wrapping_mul(len) as usize].into_boxed_slice();
+  Hacl_Bignum_Karatsuba_bn_karatsuba_sqr_uint32(len, aM, &mut tmp, &mut c);
+  bn_mont_reduction_u32(len, n, nInv_u64, &mut c, resM)
+}
+
+pub fn Hacl_Bignum_Montgomery_bn_mont_sqr_u64(
+  len: u32,
+  n: &[u64],
+  nInv_u64: u64,
+  aM: &[u64],
+  resM: &mut [u64]
+)
+{
+  let mut c: Box<[u64]> = vec![0u64; len.wrapping_add(len) as usize].into_boxed_slice();
+  let mut tmp: Box<[u64]> = vec![0u64; 4u32.wrapping_mul(len) as usize].into_boxed_slice();
+  Hacl_Bignum_Karatsuba_bn_karatsuba_sqr_uint64(len, aM, &mut tmp, &mut c);
+  bn_mont_reduction_u64(len, n, nInv_u64, &mut c, resM)
+}
+
+pub fn Hacl_Bignum_Montgomery_bn_precomp_r2_mod_n_u32(
+  len: u32,
+  nBits: u32,
+  n: &[u32],
+  res: &mut [u32]
+)
+{
+  (res[0usize..len as usize]).copy_from_slice(&vec![0u32; len as usize].into_boxed_slice());
+  let i: u32 = nBits.wrapping_div(32u32);
+  let j: u32 = nBits.wrapping_rem(32u32);
+  res[i as usize] |= 1u32.wrapping_shl(j);
+  for i0 in 0u32..64u32.wrapping_mul(len).wrapping_sub(nBits)
+  {
+    let mut a_copy: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+    let mut b_copy: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
+    ((&mut a_copy)[0usize..len as usize]).copy_from_slice(&res[0usize..len as usize]);
+    ((&mut b_copy)[0usize..len as usize]).copy_from_slice(&res[0usize..len as usize]);
+    Hacl_Bignum_bn_add_mod_n_u32(len, n, &a_copy, &b_copy, res)
+  }
+}
+
+pub fn Hacl_Bignum_Montgomery_bn_precomp_r2_mod_n_u64(
+  len: u32,
+  nBits: u32,
+  n: &[u64],
+  res: &mut [u64]
+)
+{
+  (res[0usize..len as usize]).copy_from_slice(&vec![0u64; len as usize].into_boxed_slice());
+  let i: u32 = nBits.wrapping_div(64u32);
+  let j: u32 = nBits.wrapping_rem(64u32);
+  res[i as usize] |= 1u64.wrapping_shl(j);
+  for i0 in 0u32..128u32.wrapping_mul(len).wrapping_sub(nBits)
+  {
+    let mut a_copy: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+    let mut b_copy: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
+    ((&mut a_copy)[0usize..len as usize]).copy_from_slice(&res[0usize..len as usize]);
+    ((&mut b_copy)[0usize..len as usize]).copy_from_slice(&res[0usize..len as usize]);
+    Hacl_Bignum_bn_add_mod_n_u64(len, n, &a_copy, &b_copy, res)
+  }
+}
+
+pub fn Hacl_Bignum_Montgomery_bn_to_mont_u32(
+  len: u32,
+  n: &[u32],
+  nInv: u32,
+  r2: &[u32],
+  a: &[u32],
+  aM: &mut [u32]
+)
+{
+  let mut c: Box<[u32]> = vec![0u32; len.wrapping_add(len) as usize].into_boxed_slice();
+  let mut tmp: Box<[u32]> = vec![0u32; 4u32.wrapping_mul(len) as usize].into_boxed_slice();
+  Hacl_Bignum_Karatsuba_bn_karatsuba_mul_uint32(len, a, r2, &mut tmp, &mut c);
+  bn_mont_reduction_u32(len, n, nInv, &mut c, aM)
+}
+
+pub fn Hacl_Bignum_Montgomery_bn_to_mont_u64(
+  len: u32,
+  n: &[u64],
+  nInv: u64,
+  r2: &[u64],
+  a: &[u64],
+  aM: &mut [u64]
+)
+{
+  let mut c: Box<[u64]> = vec![0u64; len.wrapping_add(len) as usize].into_boxed_slice();
+  let mut tmp: Box<[u64]> = vec![0u64; 4u32.wrapping_mul(len) as usize].into_boxed_slice();
+  Hacl_Bignum_Karatsuba_bn_karatsuba_mul_uint64(len, a, r2, &mut tmp, &mut c);
+  bn_mont_reduction_u64(len, n, nInv, &mut c, aM)
+}
+
 pub fn Hacl_Bignum_bn_add_mod_n_u32(
   len1: u32,
   n: &[u32],
@@ -858,87 +2020,50 @@ pub fn Hacl_Bignum_bn_sub_mod_n_u64(
   }
 }
 
-pub fn Hacl_Bignum_ModInvLimb_mod_inv_uint32(n0: u32) -> u32
-{
-  let alpha: u32 = 2147483648u32;
-  let beta: u32 = n0;
-  let mut ub: u32 = 0u32;
-  let mut vb: u32 = 0u32;
-  ub = 1u32;
-  vb = 0u32;
-  for i in 0u32..32u32
-  {
-    let us: u32 = ub;
-    let vs: u32 = vb;
-    let u_is_odd: u32 = 0u32.wrapping_sub(us & 1u32);
-    let beta_if_u_is_odd: u32 = beta & u_is_odd;
-    ub = (us ^ beta_if_u_is_odd).wrapping_shr(1u32).wrapping_add(us & beta_if_u_is_odd);
-    let alpha_if_u_is_odd: u32 = alpha & u_is_odd;
-    vb = vs.wrapping_shr(1u32).wrapping_add(alpha_if_u_is_odd)
-  };
-  return vb
-}
-
-pub fn Hacl_Bignum_ModInvLimb_mod_inv_uint64(n0: u64) -> u64
-{
-  let alpha: u64 = 9223372036854775808u64;
-  let beta: u64 = n0;
-  let mut ub: u64 = 0u64;
-  let mut vb: u64 = 0u64;
-  ub = 1u64;
-  vb = 0u64;
-  for i in 0u32..64u32
-  {
-    let us: u64 = ub;
-    let vs: u64 = vb;
-    let u_is_odd: u64 = 0u64.wrapping_sub(us & 1u64);
-    let beta_if_u_is_odd: u64 = beta & u_is_odd;
-    ub = (us ^ beta_if_u_is_odd).wrapping_shr(1u32).wrapping_add(us & beta_if_u_is_odd);
-    let alpha_if_u_is_odd: u64 = alpha & u_is_odd;
-    vb = vs.wrapping_shr(1u32).wrapping_add(alpha_if_u_is_odd)
-  };
-  return vb
-}
-
-pub fn Hacl_Bignum_Montgomery_bn_check_modulus_u32(len: u32, n: &[u32]) -> u32
-{
-  let mut one: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-  ((&mut one)[0usize..len as usize]).copy_from_slice(
-    &vec![0u32; len as usize].into_boxed_slice()
-  );
-  (&mut one)[0usize] = 1u32;
-  let bit0: u32 = n[0usize] & 1u32;
-  let m0: u32 = 0u32.wrapping_sub(bit0);
-  let mut acc: u32 = 0u32;
-  for i in 0u32..len
-  {
-    let beq: u32 = crate::hacl_krmllib::FStar_UInt32_eq_mask((&one)[i as usize], n[i as usize]);
-    let blt: u32 = ! crate::hacl_krmllib::FStar_UInt32_gte_mask((&one)[i as usize], n[i as usize]);
-    acc = beq & acc | ! beq & blt
-  };
-  let m1: u32 = acc;
-  return m0 & m1
-}
-
-pub fn Hacl_Bignum_Montgomery_bn_precomp_r2_mod_n_u32(
+pub fn bn_almost_mont_mul_u32(
   len: u32,
-  nBits: u32,
   n: &[u32],
-  res: &mut [u32]
+  nInv_u64: u32,
+  aM: &[u32],
+  bM: &[u32],
+  resM: &mut [u32]
 )
 {
-  (res[0usize..len as usize]).copy_from_slice(&vec![0u32; len as usize].into_boxed_slice());
-  let i: u32 = nBits.wrapping_div(32u32);
-  let j: u32 = nBits.wrapping_rem(32u32);
-  res[i as usize] |= 1u32.wrapping_shl(j);
-  for i0 in 0u32..64u32.wrapping_mul(len).wrapping_sub(nBits)
-  {
-    let mut a_copy: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-    let mut b_copy: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-    ((&mut a_copy)[0usize..len as usize]).copy_from_slice(&res[0usize..len as usize]);
-    ((&mut b_copy)[0usize..len as usize]).copy_from_slice(&res[0usize..len as usize]);
-    Hacl_Bignum_bn_add_mod_n_u32(len, n, &a_copy, &b_copy, res)
-  }
+  let mut c: Box<[u32]> = vec![0u32; len.wrapping_add(len) as usize].into_boxed_slice();
+  let mut tmp: Box<[u32]> = vec![0u32; 4u32.wrapping_mul(len) as usize].into_boxed_slice();
+  Hacl_Bignum_Karatsuba_bn_karatsuba_mul_uint32(len, aM, bM, &mut tmp, &mut c);
+  Hacl_Bignum_AlmostMontgomery_bn_almost_mont_reduction_u32(len, n, nInv_u64, &mut c, resM)
+}
+
+pub fn bn_almost_mont_mul_u64(
+  len: u32,
+  n: &[u64],
+  nInv_u64: u64,
+  aM: &[u64],
+  bM: &[u64],
+  resM: &mut [u64]
+)
+{
+  let mut c: Box<[u64]> = vec![0u64; len.wrapping_add(len) as usize].into_boxed_slice();
+  let mut tmp: Box<[u64]> = vec![0u64; 4u32.wrapping_mul(len) as usize].into_boxed_slice();
+  Hacl_Bignum_Karatsuba_bn_karatsuba_mul_uint64(len, aM, bM, &mut tmp, &mut c);
+  Hacl_Bignum_AlmostMontgomery_bn_almost_mont_reduction_u64(len, n, nInv_u64, &mut c, resM)
+}
+
+pub fn bn_almost_mont_sqr_u32(len: u32, n: &[u32], nInv_u64: u32, aM: &[u32], resM: &mut [u32])
+{
+  let mut c: Box<[u32]> = vec![0u32; len.wrapping_add(len) as usize].into_boxed_slice();
+  let mut tmp: Box<[u32]> = vec![0u32; 4u32.wrapping_mul(len) as usize].into_boxed_slice();
+  Hacl_Bignum_Karatsuba_bn_karatsuba_sqr_uint32(len, aM, &mut tmp, &mut c);
+  Hacl_Bignum_AlmostMontgomery_bn_almost_mont_reduction_u32(len, n, nInv_u64, &mut c, resM)
+}
+
+pub fn bn_almost_mont_sqr_u64(len: u32, n: &[u64], nInv_u64: u64, aM: &[u64], resM: &mut [u64])
+{
+  let mut c: Box<[u64]> = vec![0u64; len.wrapping_add(len) as usize].into_boxed_slice();
+  let mut tmp: Box<[u64]> = vec![0u64; 4u32.wrapping_mul(len) as usize].into_boxed_slice();
+  Hacl_Bignum_Karatsuba_bn_karatsuba_sqr_uint64(len, aM, &mut tmp, &mut c);
+  Hacl_Bignum_AlmostMontgomery_bn_almost_mont_reduction_u64(len, n, nInv_u64, &mut c, resM)
 }
 
 pub fn bn_mont_reduction_u32(len: u32, n: &[u32], nInv: u32, c: &mut [u32], res: &mut [u32])
@@ -1018,104 +2143,6 @@ pub fn bn_mont_reduction_u32(len: u32, n: &[u32], nInv: u32, c: &mut [u32], res:
   }
 }
 
-pub fn Hacl_Bignum_Montgomery_bn_to_mont_u32(
-  len: u32,
-  n: &[u32],
-  nInv: u32,
-  r2: &[u32],
-  a: &[u32],
-  aM: &mut [u32]
-)
-{
-  let mut c: Box<[u32]> = vec![0u32; len.wrapping_add(len) as usize].into_boxed_slice();
-  let mut tmp: Box<[u32]> = vec![0u32; 4u32.wrapping_mul(len) as usize].into_boxed_slice();
-  Hacl_Bignum_Karatsuba_bn_karatsuba_mul_uint32(len, a, r2, &mut tmp, &mut c);
-  bn_mont_reduction_u32(len, n, nInv, &mut c, aM)
-}
-
-pub fn Hacl_Bignum_Montgomery_bn_from_mont_u32(
-  len: u32,
-  n: &[u32],
-  nInv_u64: u32,
-  aM: &[u32],
-  a: &mut [u32]
-)
-{
-  let mut tmp: Box<[u32]> = vec![0u32; len.wrapping_add(len) as usize].into_boxed_slice();
-  ((&mut tmp)[0usize..len as usize]).copy_from_slice(&aM[0usize..len as usize]);
-  bn_mont_reduction_u32(len, n, nInv_u64, &mut tmp, a)
-}
-
-pub fn Hacl_Bignum_Montgomery_bn_mont_mul_u32(
-  len: u32,
-  n: &[u32],
-  nInv_u64: u32,
-  aM: &[u32],
-  bM: &[u32],
-  resM: &mut [u32]
-)
-{
-  let mut c: Box<[u32]> = vec![0u32; len.wrapping_add(len) as usize].into_boxed_slice();
-  let mut tmp: Box<[u32]> = vec![0u32; 4u32.wrapping_mul(len) as usize].into_boxed_slice();
-  Hacl_Bignum_Karatsuba_bn_karatsuba_mul_uint32(len, aM, bM, &mut tmp, &mut c);
-  bn_mont_reduction_u32(len, n, nInv_u64, &mut c, resM)
-}
-
-pub fn Hacl_Bignum_Montgomery_bn_mont_sqr_u32(
-  len: u32,
-  n: &[u32],
-  nInv_u64: u32,
-  aM: &[u32],
-  resM: &mut [u32]
-)
-{
-  let mut c: Box<[u32]> = vec![0u32; len.wrapping_add(len) as usize].into_boxed_slice();
-  let mut tmp: Box<[u32]> = vec![0u32; 4u32.wrapping_mul(len) as usize].into_boxed_slice();
-  Hacl_Bignum_Karatsuba_bn_karatsuba_sqr_uint32(len, aM, &mut tmp, &mut c);
-  bn_mont_reduction_u32(len, n, nInv_u64, &mut c, resM)
-}
-
-pub fn Hacl_Bignum_Montgomery_bn_check_modulus_u64(len: u32, n: &[u64]) -> u64
-{
-  let mut one: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-  ((&mut one)[0usize..len as usize]).copy_from_slice(
-    &vec![0u64; len as usize].into_boxed_slice()
-  );
-  (&mut one)[0usize] = 1u64;
-  let bit0: u64 = n[0usize] & 1u64;
-  let m0: u64 = 0u64.wrapping_sub(bit0);
-  let mut acc: u64 = 0u64;
-  for i in 0u32..len
-  {
-    let beq: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask((&one)[i as usize], n[i as usize]);
-    let blt: u64 = ! crate::hacl_krmllib::FStar_UInt64_gte_mask((&one)[i as usize], n[i as usize]);
-    acc = beq & acc | ! beq & blt
-  };
-  let m1: u64 = acc;
-  return m0 & m1
-}
-
-pub fn Hacl_Bignum_Montgomery_bn_precomp_r2_mod_n_u64(
-  len: u32,
-  nBits: u32,
-  n: &[u64],
-  res: &mut [u64]
-)
-{
-  (res[0usize..len as usize]).copy_from_slice(&vec![0u64; len as usize].into_boxed_slice());
-  let i: u32 = nBits.wrapping_div(64u32);
-  let j: u32 = nBits.wrapping_rem(64u32);
-  res[i as usize] |= 1u64.wrapping_shl(j);
-  for i0 in 0u32..128u32.wrapping_mul(len).wrapping_sub(nBits)
-  {
-    let mut a_copy: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-    let mut b_copy: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-    ((&mut a_copy)[0usize..len as usize]).copy_from_slice(&res[0usize..len as usize]);
-    ((&mut b_copy)[0usize..len as usize]).copy_from_slice(&res[0usize..len as usize]);
-    Hacl_Bignum_bn_add_mod_n_u64(len, n, &a_copy, &b_copy, res)
-  }
-}
-
 pub fn bn_mont_reduction_u64(len: u32, n: &[u64], nInv: u64, c: &mut [u64], res: &mut [u64])
 {
   let mut c0: u64 = 0u64;
@@ -1191,1031 +2218,4 @@ pub fn bn_mont_reduction_u64(len: u32, n: &[u64], nInv: u64, c: &mut [u64], res:
     let os: (&mut [u64], &mut [u64]) = res.split_at_mut(0usize);
     os.1[i as usize] = x
   }
-}
-
-pub fn Hacl_Bignum_Montgomery_bn_to_mont_u64(
-  len: u32,
-  n: &[u64],
-  nInv: u64,
-  r2: &[u64],
-  a: &[u64],
-  aM: &mut [u64]
-)
-{
-  let mut c: Box<[u64]> = vec![0u64; len.wrapping_add(len) as usize].into_boxed_slice();
-  let mut tmp: Box<[u64]> = vec![0u64; 4u32.wrapping_mul(len) as usize].into_boxed_slice();
-  Hacl_Bignum_Karatsuba_bn_karatsuba_mul_uint64(len, a, r2, &mut tmp, &mut c);
-  bn_mont_reduction_u64(len, n, nInv, &mut c, aM)
-}
-
-pub fn Hacl_Bignum_Montgomery_bn_from_mont_u64(
-  len: u32,
-  n: &[u64],
-  nInv_u64: u64,
-  aM: &[u64],
-  a: &mut [u64]
-)
-{
-  let mut tmp: Box<[u64]> = vec![0u64; len.wrapping_add(len) as usize].into_boxed_slice();
-  ((&mut tmp)[0usize..len as usize]).copy_from_slice(&aM[0usize..len as usize]);
-  bn_mont_reduction_u64(len, n, nInv_u64, &mut tmp, a)
-}
-
-pub fn Hacl_Bignum_Montgomery_bn_mont_mul_u64(
-  len: u32,
-  n: &[u64],
-  nInv_u64: u64,
-  aM: &[u64],
-  bM: &[u64],
-  resM: &mut [u64]
-)
-{
-  let mut c: Box<[u64]> = vec![0u64; len.wrapping_add(len) as usize].into_boxed_slice();
-  let mut tmp: Box<[u64]> = vec![0u64; 4u32.wrapping_mul(len) as usize].into_boxed_slice();
-  Hacl_Bignum_Karatsuba_bn_karatsuba_mul_uint64(len, aM, bM, &mut tmp, &mut c);
-  bn_mont_reduction_u64(len, n, nInv_u64, &mut c, resM)
-}
-
-pub fn Hacl_Bignum_Montgomery_bn_mont_sqr_u64(
-  len: u32,
-  n: &[u64],
-  nInv_u64: u64,
-  aM: &[u64],
-  resM: &mut [u64]
-)
-{
-  let mut c: Box<[u64]> = vec![0u64; len.wrapping_add(len) as usize].into_boxed_slice();
-  let mut tmp: Box<[u64]> = vec![0u64; 4u32.wrapping_mul(len) as usize].into_boxed_slice();
-  Hacl_Bignum_Karatsuba_bn_karatsuba_sqr_uint64(len, aM, &mut tmp, &mut c);
-  bn_mont_reduction_u64(len, n, nInv_u64, &mut c, resM)
-}
-
-pub fn Hacl_Bignum_AlmostMontgomery_bn_almost_mont_reduction_u32(
-  len: u32,
-  n: &[u32],
-  nInv: u32,
-  c: &mut [u32],
-  res: &mut [u32]
-)
-{
-  let mut c0: u32 = 0u32;
-  for i0 in 0u32..len
-  {
-    let qj: u32 = nInv.wrapping_mul(c[i0 as usize]);
-    let res_j0: (&mut [u32], &mut [u32]) = c.split_at_mut(i0 as usize);
-    let mut c1: u32 = 0u32;
-    for i in 0u32..len.wrapping_div(4u32)
-    {
-      let a_i: u32 = n[4u32.wrapping_mul(i) as usize];
-      let res_i0: (&mut [u32], &mut [u32]) = res_j0.1.split_at_mut(4u32.wrapping_mul(i) as usize);
-      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u32(a_i, qj, c1, res_i0.1);
-      let a_i0: u32 = n[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
-      let res_i1: (&mut [u32], &mut [u32]) = res_i0.1.split_at_mut(1usize);
-      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u32(a_i0, qj, c1, res_i1.1);
-      let a_i1: u32 = n[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
-      let res_i2: (&mut [u32], &mut [u32]) = res_i1.1.split_at_mut(1usize);
-      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u32(a_i1, qj, c1, res_i2.1);
-      let a_i2: u32 = n[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
-      let res_i: (&mut [u32], &mut [u32]) = res_i2.1.split_at_mut(1usize);
-      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, qj, c1, res_i.1)
-    };
-    for i in len.wrapping_div(4u32).wrapping_mul(4u32)..len
-    {
-      let a_i: u32 = n[i as usize];
-      let res_i: (&mut [u32], &mut [u32]) = res_j0.1.split_at_mut(i as usize);
-      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u32(a_i, qj, c1, res_i.1)
-    };
-    let r: u32 = c1;
-    let c10: u32 = r;
-    let res_j: u32 = c[len.wrapping_add(i0) as usize];
-    let resb: (&mut [u32], &mut [u32]) = c.split_at_mut(len.wrapping_add(i0) as usize);
-    c0 = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u32(c0, c10, res_j, resb.1)
-  };
-  (res[0usize..len.wrapping_add(len).wrapping_sub(len) as usize]).copy_from_slice(
-    &(&c[len as usize..])[0usize..len.wrapping_add(len).wrapping_sub(len) as usize]
-  );
-  let c00: u32 = c0;
-  let mut tmp: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-  let c1: u32 =
-      crate::hacl::bignum_base::Hacl_Bignum_Addition_bn_sub_eq_len_u32(len, res, n, &mut tmp);
-  crate::lowstar::ignore::ignore::<u32>(c1);
-  let m: u32 = 0u32.wrapping_sub(c00);
-  for i in 0u32..len
-  {
-    let x: u32 = m & (&tmp)[i as usize] | ! m & res[i as usize];
-    let os: (&mut [u32], &mut [u32]) = res.split_at_mut(0usize);
-    os.1[i as usize] = x
-  }
-}
-
-pub fn bn_almost_mont_mul_u32(
-  len: u32,
-  n: &[u32],
-  nInv_u64: u32,
-  aM: &[u32],
-  bM: &[u32],
-  resM: &mut [u32]
-)
-{
-  let mut c: Box<[u32]> = vec![0u32; len.wrapping_add(len) as usize].into_boxed_slice();
-  let mut tmp: Box<[u32]> = vec![0u32; 4u32.wrapping_mul(len) as usize].into_boxed_slice();
-  Hacl_Bignum_Karatsuba_bn_karatsuba_mul_uint32(len, aM, bM, &mut tmp, &mut c);
-  Hacl_Bignum_AlmostMontgomery_bn_almost_mont_reduction_u32(len, n, nInv_u64, &mut c, resM)
-}
-
-pub fn bn_almost_mont_sqr_u32(len: u32, n: &[u32], nInv_u64: u32, aM: &[u32], resM: &mut [u32])
-{
-  let mut c: Box<[u32]> = vec![0u32; len.wrapping_add(len) as usize].into_boxed_slice();
-  let mut tmp: Box<[u32]> = vec![0u32; 4u32.wrapping_mul(len) as usize].into_boxed_slice();
-  Hacl_Bignum_Karatsuba_bn_karatsuba_sqr_uint32(len, aM, &mut tmp, &mut c);
-  Hacl_Bignum_AlmostMontgomery_bn_almost_mont_reduction_u32(len, n, nInv_u64, &mut c, resM)
-}
-
-pub fn Hacl_Bignum_AlmostMontgomery_bn_almost_mont_reduction_u64(
-  len: u32,
-  n: &[u64],
-  nInv: u64,
-  c: &mut [u64],
-  res: &mut [u64]
-)
-{
-  let mut c0: u64 = 0u64;
-  for i0 in 0u32..len
-  {
-    let qj: u64 = nInv.wrapping_mul(c[i0 as usize]);
-    let res_j0: (&mut [u64], &mut [u64]) = c.split_at_mut(i0 as usize);
-    let mut c1: u64 = 0u64;
-    for i in 0u32..len.wrapping_div(4u32)
-    {
-      let a_i: u64 = n[4u32.wrapping_mul(i) as usize];
-      let res_i0: (&mut [u64], &mut [u64]) = res_j0.1.split_at_mut(4u32.wrapping_mul(i) as usize);
-      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c1, res_i0.1);
-      let a_i0: u64 = n[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
-      let res_i1: (&mut [u64], &mut [u64]) = res_i0.1.split_at_mut(1usize);
-      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, qj, c1, res_i1.1);
-      let a_i1: u64 = n[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
-      let res_i2: (&mut [u64], &mut [u64]) = res_i1.1.split_at_mut(1usize);
-      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, qj, c1, res_i2.1);
-      let a_i2: u64 = n[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
-      let res_i: (&mut [u64], &mut [u64]) = res_i2.1.split_at_mut(1usize);
-      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, qj, c1, res_i.1)
-    };
-    for i in len.wrapping_div(4u32).wrapping_mul(4u32)..len
-    {
-      let a_i: u64 = n[i as usize];
-      let res_i: (&mut [u64], &mut [u64]) = res_j0.1.split_at_mut(i as usize);
-      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c1, res_i.1)
-    };
-    let r: u64 = c1;
-    let c10: u64 = r;
-    let res_j: u64 = c[len.wrapping_add(i0) as usize];
-    let resb: (&mut [u64], &mut [u64]) = c.split_at_mut(len.wrapping_add(i0) as usize);
-    c0 = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u64(c0, c10, res_j, resb.1)
-  };
-  (res[0usize..len.wrapping_add(len).wrapping_sub(len) as usize]).copy_from_slice(
-    &(&c[len as usize..])[0usize..len.wrapping_add(len).wrapping_sub(len) as usize]
-  );
-  let c00: u64 = c0;
-  let mut tmp: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-  let c1: u64 =
-      crate::hacl::bignum_base::Hacl_Bignum_Addition_bn_sub_eq_len_u64(len, res, n, &mut tmp);
-  crate::lowstar::ignore::ignore::<u64>(c1);
-  let m: u64 = 0u64.wrapping_sub(c00);
-  for i in 0u32..len
-  {
-    let x: u64 = m & (&tmp)[i as usize] | ! m & res[i as usize];
-    let os: (&mut [u64], &mut [u64]) = res.split_at_mut(0usize);
-    os.1[i as usize] = x
-  }
-}
-
-pub fn bn_almost_mont_mul_u64(
-  len: u32,
-  n: &[u64],
-  nInv_u64: u64,
-  aM: &[u64],
-  bM: &[u64],
-  resM: &mut [u64]
-)
-{
-  let mut c: Box<[u64]> = vec![0u64; len.wrapping_add(len) as usize].into_boxed_slice();
-  let mut tmp: Box<[u64]> = vec![0u64; 4u32.wrapping_mul(len) as usize].into_boxed_slice();
-  Hacl_Bignum_Karatsuba_bn_karatsuba_mul_uint64(len, aM, bM, &mut tmp, &mut c);
-  Hacl_Bignum_AlmostMontgomery_bn_almost_mont_reduction_u64(len, n, nInv_u64, &mut c, resM)
-}
-
-pub fn bn_almost_mont_sqr_u64(len: u32, n: &[u64], nInv_u64: u64, aM: &[u64], resM: &mut [u64])
-{
-  let mut c: Box<[u64]> = vec![0u64; len.wrapping_add(len) as usize].into_boxed_slice();
-  let mut tmp: Box<[u64]> = vec![0u64; 4u32.wrapping_mul(len) as usize].into_boxed_slice();
-  Hacl_Bignum_Karatsuba_bn_karatsuba_sqr_uint64(len, aM, &mut tmp, &mut c);
-  Hacl_Bignum_AlmostMontgomery_bn_almost_mont_reduction_u64(len, n, nInv_u64, &mut c, resM)
-}
-
-pub fn Hacl_Bignum_Exponentiation_bn_check_mod_exp_u32(
-  len: u32,
-  n: &[u32],
-  a: &[u32],
-  bBits: u32,
-  b: &[u32]
-) ->
-    u32
-{
-  let mut one: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-  ((&mut one)[0usize..len as usize]).copy_from_slice(
-    &vec![0u32; len as usize].into_boxed_slice()
-  );
-  (&mut one)[0usize] = 1u32;
-  let bit0: u32 = n[0usize] & 1u32;
-  let m0: u32 = 0u32.wrapping_sub(bit0);
-  let mut acc0: u32 = 0u32;
-  for i in 0u32..len
-  {
-    let beq: u32 = crate::hacl_krmllib::FStar_UInt32_eq_mask((&one)[i as usize], n[i as usize]);
-    let blt: u32 = ! crate::hacl_krmllib::FStar_UInt32_gte_mask((&one)[i as usize], n[i as usize]);
-    acc0 = beq & acc0 | ! beq & blt
-  };
-  let m10: u32 = acc0;
-  let m00: u32 = m0 & m10;
-  let mut bLen: u32;
-  if bBits == 0u32
-  { bLen = 1u32 }
-  else
-  { bLen = bBits.wrapping_sub(1u32).wrapping_div(32u32).wrapping_add(1u32) };
-  let mut m1: u32;
-  if bBits < 32u32.wrapping_mul(bLen)
-  {
-    let mut b2: Box<[u32]> = vec![0u32; bLen as usize].into_boxed_slice();
-    let i0: u32 = bBits.wrapping_div(32u32);
-    let j: u32 = bBits.wrapping_rem(32u32);
-    (&mut b2)[i0 as usize] = (&b2)[i0 as usize] | 1u32.wrapping_shl(j);
-    let mut acc: u32 = 0u32;
-    for i in 0u32..bLen
-    {
-      let beq: u32 = crate::hacl_krmllib::FStar_UInt32_eq_mask(b[i as usize], (&b2)[i as usize]);
-      let blt: u32 = ! crate::hacl_krmllib::FStar_UInt32_gte_mask(b[i as usize], (&b2)[i as usize]);
-      acc = beq & acc | ! beq & blt
-    };
-    let res: u32 = acc;
-    m1 = res
-  }
-  else
-  { m1 = 4294967295u32 };
-  let mut acc: u32 = 0u32;
-  for i in 0u32..len
-  {
-    let beq: u32 = crate::hacl_krmllib::FStar_UInt32_eq_mask(a[i as usize], n[i as usize]);
-    let blt: u32 = ! crate::hacl_krmllib::FStar_UInt32_gte_mask(a[i as usize], n[i as usize]);
-    acc = beq & acc | ! beq & blt
-  };
-  let m2: u32 = acc;
-  let m: u32 = m1 & m2;
-  return m00 & m
-}
-
-pub fn Hacl_Bignum_Exponentiation_bn_mod_exp_vartime_precomp_u32(
-  len: u32,
-  n: &[u32],
-  mu: u32,
-  r2: &[u32],
-  a: &[u32],
-  bBits: u32,
-  b: &[u32],
-  res: &mut [u32]
-)
-{
-  if bBits < 200u32
-  {
-    let mut aM: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-    Hacl_Bignum_Montgomery_bn_to_mont_u32(len, n, mu, r2, a, &mut aM);
-    let mut resM: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-    let mut ctx: Box<[u32]> = vec![0u32; len.wrapping_add(len) as usize].into_boxed_slice();
-    ((&mut ctx)[0usize..len as usize]).copy_from_slice(&n[0usize..len as usize]);
-    ((&mut (&mut ctx)[len as usize..])[0usize..len as usize]).copy_from_slice(
-      &r2[0usize..len as usize]
-    );
-    let ctx_n0: (&[u32], &[u32]) = ctx.split_at(0usize);
-    let ctx_r2: (&[u32], &[u32]) = ctx_n0.1.split_at(len as usize);
-    Hacl_Bignum_Montgomery_bn_from_mont_u32(len, ctx_r2.0, mu, ctx_r2.1, &mut resM);
-    crate::lowstar::ignore::ignore::<&[u32]>(&ctx);
-    for i in 0u32..bBits
-    {
-      let i1: u32 = i.wrapping_div(32u32);
-      let j: u32 = i.wrapping_rem(32u32);
-      let tmp: u32 = b[i1 as usize];
-      let bit: u32 = tmp.wrapping_shr(j) & 1u32;
-      if bit != 0u32
-      {
-        let mut aM_copy: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-        ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&resM)[0usize..len as usize]);
-        let ctx_n: (&[u32], &[u32]) = ctx.split_at(0usize);
-        bn_almost_mont_mul_u32(len, ctx_n.1, mu, &aM_copy, &aM, &mut resM);
-        crate::lowstar::ignore::ignore::<&[u32]>(&ctx)
-      };
-      let mut aM_copy: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-      ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&aM)[0usize..len as usize]);
-      let ctx_n: (&[u32], &[u32]) = ctx.split_at(0usize);
-      bn_almost_mont_sqr_u32(len, ctx_n.1, mu, &aM_copy, &mut aM);
-      crate::lowstar::ignore::ignore::<&[u32]>(&ctx)
-    };
-    Hacl_Bignum_Montgomery_bn_from_mont_u32(len, n, mu, &resM, res);
-    return ()
-  };
-  let mut aM: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-  Hacl_Bignum_Montgomery_bn_to_mont_u32(len, n, mu, r2, a, &mut aM);
-  let mut resM: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-  let mut bLen: u32;
-  if bBits == 0u32
-  { bLen = 1u32 }
-  else
-  { bLen = bBits.wrapping_sub(1u32).wrapping_div(32u32).wrapping_add(1u32) };
-  let mut ctx: Box<[u32]> = vec![0u32; len.wrapping_add(len) as usize].into_boxed_slice();
-  ((&mut ctx)[0usize..len as usize]).copy_from_slice(&n[0usize..len as usize]);
-  ((&mut (&mut ctx)[len as usize..])[0usize..len as usize]).copy_from_slice(
-    &r2[0usize..len as usize]
-  );
-  let mut table: Box<[u32]> = vec![0u32; 16u32.wrapping_mul(len) as usize].into_boxed_slice();
-  let mut tmp: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-  let t0: (&mut [u32], &mut [u32]) = table.split_at_mut(0usize);
-  let t1: (&mut [u32], &mut [u32]) = t0.1.split_at_mut(len as usize);
-  let ctx_n0: (&[u32], &[u32]) = ctx.split_at(0usize);
-  let ctx_r20: (&[u32], &[u32]) = ctx_n0.1.split_at(len as usize);
-  Hacl_Bignum_Montgomery_bn_from_mont_u32(len, ctx_r20.0, mu, ctx_r20.1, t1.0);
-  crate::lowstar::ignore::ignore::<&[u32]>(&ctx);
-  (t1.1[0usize..len as usize]).copy_from_slice(&(&aM)[0usize..len as usize]);
-  crate::lowstar::ignore::ignore::<&[u32]>(&table);
-  for i in 0u32..7u32
-  {
-    let t11: (&[u32], &[u32]) = table.split_at(i.wrapping_add(1u32).wrapping_mul(len) as usize);
-    let mut aM_copy0: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-    ((&mut aM_copy0)[0usize..len as usize]).copy_from_slice(&t11.1[0usize..len as usize]);
-    let ctx_n1: (&[u32], &[u32]) = ctx.split_at(0usize);
-    bn_almost_mont_sqr_u32(len, ctx_n1.1, mu, &aM_copy0, &mut tmp);
-    crate::lowstar::ignore::ignore::<&[u32]>(&ctx);
-    ((&mut (&mut table)[2u32.wrapping_mul(i).wrapping_add(2u32).wrapping_mul(len) as usize..])[0usize..len
-    as
-    usize]).copy_from_slice(&(&tmp)[0usize..len as usize]);
-    let t2: (&[u32], &[u32]) =
-        table.split_at(2u32.wrapping_mul(i).wrapping_add(2u32).wrapping_mul(len) as usize);
-    let mut aM_copy: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-    ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&aM)[0usize..len as usize]);
-    let ctx_n: (&[u32], &[u32]) = ctx.split_at(0usize);
-    bn_almost_mont_mul_u32(len, ctx_n.1, mu, &aM_copy, t2.1, &mut tmp);
-    crate::lowstar::ignore::ignore::<&[u32]>(&ctx);
-    ((&mut (&mut table)[2u32.wrapping_mul(i).wrapping_add(3u32).wrapping_mul(len) as usize..])[0usize..len
-    as
-    usize]).copy_from_slice(&(&tmp)[0usize..len as usize])
-  };
-  if bBits.wrapping_rem(4u32) != 0u32
-  {
-    let i: u32 = bBits.wrapping_div(4u32).wrapping_mul(4u32);
-    let bits_c: u32 = crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_bits_u32(bLen, b, i, 4u32);
-    let bits_l32: u32 = bits_c;
-    let a_bits_l: (&[u32], &[u32]) = table.split_at(bits_l32.wrapping_mul(len) as usize);
-    ((&mut resM)[0usize..len as usize]).copy_from_slice(&a_bits_l.1[0usize..len as usize])
-  }
-  else
-  {
-    let ctx_n: (&[u32], &[u32]) = ctx.split_at(0usize);
-    let ctx_r2: (&[u32], &[u32]) = ctx_n.1.split_at(len as usize);
-    Hacl_Bignum_Montgomery_bn_from_mont_u32(len, ctx_r2.0, mu, ctx_r2.1, &mut resM);
-    crate::lowstar::ignore::ignore::<&[u32]>(&ctx)
-  };
-  let mut tmp0: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-  for i in 0u32..bBits.wrapping_div(4u32)
-  {
-    for i0 in 0u32..4u32
-    {
-      let mut aM_copy: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-      ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&resM)[0usize..len as usize]);
-      let ctx_n: (&[u32], &[u32]) = ctx.split_at(0usize);
-      bn_almost_mont_sqr_u32(len, ctx_n.1, mu, &aM_copy, &mut resM);
-      crate::lowstar::ignore::ignore::<&[u32]>(&ctx)
-    };
-    let k: u32 =
-        bBits.wrapping_sub(bBits.wrapping_rem(4u32)).wrapping_sub(4u32.wrapping_mul(i)).wrapping_sub(
-          4u32
-        );
-    let bits_l: u32 = crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_bits_u32(bLen, b, k, 4u32);
-    crate::lowstar::ignore::ignore::<&[u32]>(&table);
-    let bits_l32: u32 = bits_l;
-    let a_bits_l: (&[u32], &[u32]) = table.split_at(bits_l32.wrapping_mul(len) as usize);
-    ((&mut tmp0)[0usize..len as usize]).copy_from_slice(&a_bits_l.1[0usize..len as usize]);
-    let mut aM_copy: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-    ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&resM)[0usize..len as usize]);
-    let ctx_n: (&[u32], &[u32]) = ctx.split_at(0usize);
-    bn_almost_mont_mul_u32(len, ctx_n.1, mu, &aM_copy, &tmp0, &mut resM);
-    crate::lowstar::ignore::ignore::<&[u32]>(&ctx)
-  };
-  Hacl_Bignum_Montgomery_bn_from_mont_u32(len, n, mu, &resM, res)
-}
-
-pub fn Hacl_Bignum_Exponentiation_bn_mod_exp_consttime_precomp_u32(
-  len: u32,
-  n: &[u32],
-  mu: u32,
-  r2: &[u32],
-  a: &[u32],
-  bBits: u32,
-  b: &[u32],
-  res: &mut [u32]
-)
-{
-  if bBits < 200u32
-  {
-    let mut aM: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-    Hacl_Bignum_Montgomery_bn_to_mont_u32(len, n, mu, r2, a, &mut aM);
-    let mut resM: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-    let mut ctx: Box<[u32]> = vec![0u32; len.wrapping_add(len) as usize].into_boxed_slice();
-    ((&mut ctx)[0usize..len as usize]).copy_from_slice(&n[0usize..len as usize]);
-    ((&mut (&mut ctx)[len as usize..])[0usize..len as usize]).copy_from_slice(
-      &r2[0usize..len as usize]
-    );
-    let mut sw: u32 = 0u32;
-    let ctx_n0: (&[u32], &[u32]) = ctx.split_at(0usize);
-    let ctx_r2: (&[u32], &[u32]) = ctx_n0.1.split_at(len as usize);
-    Hacl_Bignum_Montgomery_bn_from_mont_u32(len, ctx_r2.0, mu, ctx_r2.1, &mut resM);
-    crate::lowstar::ignore::ignore::<&[u32]>(&ctx);
-    for i0 in 0u32..bBits
-    {
-      let i1: u32 = bBits.wrapping_sub(i0).wrapping_sub(1u32).wrapping_div(32u32);
-      let j: u32 = bBits.wrapping_sub(i0).wrapping_sub(1u32).wrapping_rem(32u32);
-      let tmp: u32 = b[i1 as usize];
-      let bit: u32 = tmp.wrapping_shr(j) & 1u32;
-      let sw1: u32 = bit ^ sw;
-      for i in 0u32..len
-      {
-        let dummy: u32 = 0u32.wrapping_sub(sw1) & ((&resM)[i as usize] ^ (&aM)[i as usize]);
-        (&mut resM)[i as usize] = (&resM)[i as usize] ^ dummy;
-        (&mut aM)[i as usize] = (&aM)[i as usize] ^ dummy
-      };
-      let mut aM_copy: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-      ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&aM)[0usize..len as usize]);
-      let ctx_n1: (&[u32], &[u32]) = ctx.split_at(0usize);
-      bn_almost_mont_mul_u32(len, ctx_n1.1, mu, &aM_copy, &resM, &mut aM);
-      crate::lowstar::ignore::ignore::<&[u32]>(&ctx);
-      let mut aM_copy0: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-      ((&mut aM_copy0)[0usize..len as usize]).copy_from_slice(&(&resM)[0usize..len as usize]);
-      let ctx_n: (&[u32], &[u32]) = ctx.split_at(0usize);
-      bn_almost_mont_sqr_u32(len, ctx_n.1, mu, &aM_copy0, &mut resM);
-      crate::lowstar::ignore::ignore::<&[u32]>(&ctx);
-      sw = bit
-    };
-    let sw0: u32 = sw;
-    for i in 0u32..len
-    {
-      let dummy: u32 = 0u32.wrapping_sub(sw0) & ((&resM)[i as usize] ^ (&aM)[i as usize]);
-      (&mut resM)[i as usize] = (&resM)[i as usize] ^ dummy;
-      (&mut aM)[i as usize] = (&aM)[i as usize] ^ dummy
-    };
-    Hacl_Bignum_Montgomery_bn_from_mont_u32(len, n, mu, &resM, res);
-    return ()
-  };
-  let mut aM: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-  Hacl_Bignum_Montgomery_bn_to_mont_u32(len, n, mu, r2, a, &mut aM);
-  let mut resM: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-  let mut bLen: u32;
-  if bBits == 0u32
-  { bLen = 1u32 }
-  else
-  { bLen = bBits.wrapping_sub(1u32).wrapping_div(32u32).wrapping_add(1u32) };
-  let mut ctx: Box<[u32]> = vec![0u32; len.wrapping_add(len) as usize].into_boxed_slice();
-  ((&mut ctx)[0usize..len as usize]).copy_from_slice(&n[0usize..len as usize]);
-  ((&mut (&mut ctx)[len as usize..])[0usize..len as usize]).copy_from_slice(
-    &r2[0usize..len as usize]
-  );
-  let mut table: Box<[u32]> = vec![0u32; 16u32.wrapping_mul(len) as usize].into_boxed_slice();
-  let mut tmp: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-  let t0: (&mut [u32], &mut [u32]) = table.split_at_mut(0usize);
-  let t1: (&mut [u32], &mut [u32]) = t0.1.split_at_mut(len as usize);
-  let ctx_n0: (&[u32], &[u32]) = ctx.split_at(0usize);
-  let ctx_r20: (&[u32], &[u32]) = ctx_n0.1.split_at(len as usize);
-  Hacl_Bignum_Montgomery_bn_from_mont_u32(len, ctx_r20.0, mu, ctx_r20.1, t1.0);
-  crate::lowstar::ignore::ignore::<&[u32]>(&ctx);
-  (t1.1[0usize..len as usize]).copy_from_slice(&(&aM)[0usize..len as usize]);
-  crate::lowstar::ignore::ignore::<&[u32]>(&table);
-  for i in 0u32..7u32
-  {
-    let t11: (&[u32], &[u32]) = table.split_at(i.wrapping_add(1u32).wrapping_mul(len) as usize);
-    let mut aM_copy0: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-    ((&mut aM_copy0)[0usize..len as usize]).copy_from_slice(&t11.1[0usize..len as usize]);
-    let ctx_n1: (&[u32], &[u32]) = ctx.split_at(0usize);
-    bn_almost_mont_sqr_u32(len, ctx_n1.1, mu, &aM_copy0, &mut tmp);
-    crate::lowstar::ignore::ignore::<&[u32]>(&ctx);
-    ((&mut (&mut table)[2u32.wrapping_mul(i).wrapping_add(2u32).wrapping_mul(len) as usize..])[0usize..len
-    as
-    usize]).copy_from_slice(&(&tmp)[0usize..len as usize]);
-    let t2: (&[u32], &[u32]) =
-        table.split_at(2u32.wrapping_mul(i).wrapping_add(2u32).wrapping_mul(len) as usize);
-    let mut aM_copy: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-    ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&aM)[0usize..len as usize]);
-    let ctx_n: (&[u32], &[u32]) = ctx.split_at(0usize);
-    bn_almost_mont_mul_u32(len, ctx_n.1, mu, &aM_copy, t2.1, &mut tmp);
-    crate::lowstar::ignore::ignore::<&[u32]>(&ctx);
-    ((&mut (&mut table)[2u32.wrapping_mul(i).wrapping_add(3u32).wrapping_mul(len) as usize..])[0usize..len
-    as
-    usize]).copy_from_slice(&(&tmp)[0usize..len as usize])
-  };
-  if bBits.wrapping_rem(4u32) != 0u32
-  {
-    let i0: u32 = bBits.wrapping_div(4u32).wrapping_mul(4u32);
-    let bits_c: u32 = crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_bits_u32(bLen, b, i0, 4u32);
-    ((&mut resM)[0usize..len as usize]).copy_from_slice(
-      &(&(&table)[0u32.wrapping_mul(len) as usize..])[0usize..len as usize]
-    );
-    for i1 in 0u32..15u32
-    {
-      let c: u32 = crate::hacl_krmllib::FStar_UInt32_eq_mask(bits_c, i1.wrapping_add(1u32));
-      let res_j: (&[u32], &[u32]) =
-          table.split_at(i1.wrapping_add(1u32).wrapping_mul(len) as usize);
-      for i in 0u32..len
-      {
-        let x: u32 = c & res_j.1[i as usize] | ! c & (&resM)[i as usize];
-        let os: (&mut [u32], &mut [u32]) = resM.split_at_mut(0usize);
-        os.1[i as usize] = x
-      }
-    }
-  }
-  else
-  {
-    let ctx_n: (&[u32], &[u32]) = ctx.split_at(0usize);
-    let ctx_r2: (&[u32], &[u32]) = ctx_n.1.split_at(len as usize);
-    Hacl_Bignum_Montgomery_bn_from_mont_u32(len, ctx_r2.0, mu, ctx_r2.1, &mut resM);
-    crate::lowstar::ignore::ignore::<&[u32]>(&ctx)
-  };
-  let mut tmp0: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-  for i0 in 0u32..bBits.wrapping_div(4u32)
-  {
-    for i in 0u32..4u32
-    {
-      let mut aM_copy: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-      ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&resM)[0usize..len as usize]);
-      let ctx_n: (&[u32], &[u32]) = ctx.split_at(0usize);
-      bn_almost_mont_sqr_u32(len, ctx_n.1, mu, &aM_copy, &mut resM);
-      crate::lowstar::ignore::ignore::<&[u32]>(&ctx)
-    };
-    let k: u32 =
-        bBits.wrapping_sub(bBits.wrapping_rem(4u32)).wrapping_sub(4u32.wrapping_mul(i0)).wrapping_sub(
-          4u32
-        );
-    let bits_l: u32 = crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_bits_u32(bLen, b, k, 4u32);
-    crate::lowstar::ignore::ignore::<&[u32]>(&table);
-    ((&mut tmp0)[0usize..len as usize]).copy_from_slice(
-      &(&(&table)[0u32.wrapping_mul(len) as usize..])[0usize..len as usize]
-    );
-    for i1 in 0u32..15u32
-    {
-      let c: u32 = crate::hacl_krmllib::FStar_UInt32_eq_mask(bits_l, i1.wrapping_add(1u32));
-      let res_j: (&[u32], &[u32]) =
-          table.split_at(i1.wrapping_add(1u32).wrapping_mul(len) as usize);
-      for i in 0u32..len
-      {
-        let x: u32 = c & res_j.1[i as usize] | ! c & (&tmp0)[i as usize];
-        let os: (&mut [u32], &mut [u32]) = tmp0.split_at_mut(0usize);
-        os.1[i as usize] = x
-      }
-    };
-    let mut aM_copy: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-    ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&resM)[0usize..len as usize]);
-    let ctx_n: (&[u32], &[u32]) = ctx.split_at(0usize);
-    bn_almost_mont_mul_u32(len, ctx_n.1, mu, &aM_copy, &tmp0, &mut resM);
-    crate::lowstar::ignore::ignore::<&[u32]>(&ctx)
-  };
-  Hacl_Bignum_Montgomery_bn_from_mont_u32(len, n, mu, &resM, res)
-}
-
-pub fn Hacl_Bignum_Exponentiation_bn_mod_exp_vartime_u32(
-  len: u32,
-  nBits: u32,
-  n: &[u32],
-  a: &[u32],
-  bBits: u32,
-  b: &[u32],
-  res: &mut [u32]
-)
-{
-  let mut r2: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-  Hacl_Bignum_Montgomery_bn_precomp_r2_mod_n_u32(len, nBits, n, &mut r2);
-  let mu: u32 = Hacl_Bignum_ModInvLimb_mod_inv_uint32(n[0usize]);
-  Hacl_Bignum_Exponentiation_bn_mod_exp_vartime_precomp_u32(len, n, mu, &r2, a, bBits, b, res)
-}
-
-pub fn Hacl_Bignum_Exponentiation_bn_mod_exp_consttime_u32(
-  len: u32,
-  nBits: u32,
-  n: &[u32],
-  a: &[u32],
-  bBits: u32,
-  b: &[u32],
-  res: &mut [u32]
-)
-{
-  let mut r2: Box<[u32]> = vec![0u32; len as usize].into_boxed_slice();
-  Hacl_Bignum_Montgomery_bn_precomp_r2_mod_n_u32(len, nBits, n, &mut r2);
-  let mu: u32 = Hacl_Bignum_ModInvLimb_mod_inv_uint32(n[0usize]);
-  Hacl_Bignum_Exponentiation_bn_mod_exp_consttime_precomp_u32(len, n, mu, &r2, a, bBits, b, res)
-}
-
-pub fn Hacl_Bignum_Exponentiation_bn_check_mod_exp_u64(
-  len: u32,
-  n: &[u64],
-  a: &[u64],
-  bBits: u32,
-  b: &[u64]
-) ->
-    u64
-{
-  let mut one: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-  ((&mut one)[0usize..len as usize]).copy_from_slice(
-    &vec![0u64; len as usize].into_boxed_slice()
-  );
-  (&mut one)[0usize] = 1u64;
-  let bit0: u64 = n[0usize] & 1u64;
-  let m0: u64 = 0u64.wrapping_sub(bit0);
-  let mut acc0: u64 = 0u64;
-  for i in 0u32..len
-  {
-    let beq: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask((&one)[i as usize], n[i as usize]);
-    let blt: u64 = ! crate::hacl_krmllib::FStar_UInt64_gte_mask((&one)[i as usize], n[i as usize]);
-    acc0 = beq & acc0 | ! beq & blt
-  };
-  let m10: u64 = acc0;
-  let m00: u64 = m0 & m10;
-  let mut bLen: u32;
-  if bBits == 0u32
-  { bLen = 1u32 }
-  else
-  { bLen = bBits.wrapping_sub(1u32).wrapping_div(64u32).wrapping_add(1u32) };
-  let mut m1: u64;
-  if bBits < 64u32.wrapping_mul(bLen)
-  {
-    let mut b2: Box<[u64]> = vec![0u64; bLen as usize].into_boxed_slice();
-    let i0: u32 = bBits.wrapping_div(64u32);
-    let j: u32 = bBits.wrapping_rem(64u32);
-    (&mut b2)[i0 as usize] = (&b2)[i0 as usize] | 1u64.wrapping_shl(j);
-    let mut acc: u64 = 0u64;
-    for i in 0u32..bLen
-    {
-      let beq: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask(b[i as usize], (&b2)[i as usize]);
-      let blt: u64 = ! crate::hacl_krmllib::FStar_UInt64_gte_mask(b[i as usize], (&b2)[i as usize]);
-      acc = beq & acc | ! beq & blt
-    };
-    let res: u64 = acc;
-    m1 = res
-  }
-  else
-  { m1 = 18446744073709551615u64 };
-  let mut acc: u64 = 0u64;
-  for i in 0u32..len
-  {
-    let beq: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask(a[i as usize], n[i as usize]);
-    let blt: u64 = ! crate::hacl_krmllib::FStar_UInt64_gte_mask(a[i as usize], n[i as usize]);
-    acc = beq & acc | ! beq & blt
-  };
-  let m2: u64 = acc;
-  let m: u64 = m1 & m2;
-  return m00 & m
-}
-
-pub fn Hacl_Bignum_Exponentiation_bn_mod_exp_vartime_precomp_u64(
-  len: u32,
-  n: &[u64],
-  mu: u64,
-  r2: &[u64],
-  a: &[u64],
-  bBits: u32,
-  b: &[u64],
-  res: &mut [u64]
-)
-{
-  if bBits < 200u32
-  {
-    let mut aM: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-    Hacl_Bignum_Montgomery_bn_to_mont_u64(len, n, mu, r2, a, &mut aM);
-    let mut resM: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-    let mut ctx: Box<[u64]> = vec![0u64; len.wrapping_add(len) as usize].into_boxed_slice();
-    ((&mut ctx)[0usize..len as usize]).copy_from_slice(&n[0usize..len as usize]);
-    ((&mut (&mut ctx)[len as usize..])[0usize..len as usize]).copy_from_slice(
-      &r2[0usize..len as usize]
-    );
-    let ctx_n0: (&[u64], &[u64]) = ctx.split_at(0usize);
-    let ctx_r2: (&[u64], &[u64]) = ctx_n0.1.split_at(len as usize);
-    Hacl_Bignum_Montgomery_bn_from_mont_u64(len, ctx_r2.0, mu, ctx_r2.1, &mut resM);
-    crate::lowstar::ignore::ignore::<&[u64]>(&ctx);
-    for i in 0u32..bBits
-    {
-      let i1: u32 = i.wrapping_div(64u32);
-      let j: u32 = i.wrapping_rem(64u32);
-      let tmp: u64 = b[i1 as usize];
-      let bit: u64 = tmp.wrapping_shr(j) & 1u64;
-      if bit != 0u64
-      {
-        let mut aM_copy: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-        ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&resM)[0usize..len as usize]);
-        let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
-        bn_almost_mont_mul_u64(len, ctx_n.1, mu, &aM_copy, &aM, &mut resM);
-        crate::lowstar::ignore::ignore::<&[u64]>(&ctx)
-      };
-      let mut aM_copy: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-      ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&aM)[0usize..len as usize]);
-      let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
-      bn_almost_mont_sqr_u64(len, ctx_n.1, mu, &aM_copy, &mut aM);
-      crate::lowstar::ignore::ignore::<&[u64]>(&ctx)
-    };
-    Hacl_Bignum_Montgomery_bn_from_mont_u64(len, n, mu, &resM, res);
-    return ()
-  };
-  let mut aM: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-  Hacl_Bignum_Montgomery_bn_to_mont_u64(len, n, mu, r2, a, &mut aM);
-  let mut resM: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-  let mut bLen: u32;
-  if bBits == 0u32
-  { bLen = 1u32 }
-  else
-  { bLen = bBits.wrapping_sub(1u32).wrapping_div(64u32).wrapping_add(1u32) };
-  let mut ctx: Box<[u64]> = vec![0u64; len.wrapping_add(len) as usize].into_boxed_slice();
-  ((&mut ctx)[0usize..len as usize]).copy_from_slice(&n[0usize..len as usize]);
-  ((&mut (&mut ctx)[len as usize..])[0usize..len as usize]).copy_from_slice(
-    &r2[0usize..len as usize]
-  );
-  let mut table: Box<[u64]> = vec![0u64; 16u32.wrapping_mul(len) as usize].into_boxed_slice();
-  let mut tmp: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-  let t0: (&mut [u64], &mut [u64]) = table.split_at_mut(0usize);
-  let t1: (&mut [u64], &mut [u64]) = t0.1.split_at_mut(len as usize);
-  let ctx_n0: (&[u64], &[u64]) = ctx.split_at(0usize);
-  let ctx_r20: (&[u64], &[u64]) = ctx_n0.1.split_at(len as usize);
-  Hacl_Bignum_Montgomery_bn_from_mont_u64(len, ctx_r20.0, mu, ctx_r20.1, t1.0);
-  crate::lowstar::ignore::ignore::<&[u64]>(&ctx);
-  (t1.1[0usize..len as usize]).copy_from_slice(&(&aM)[0usize..len as usize]);
-  crate::lowstar::ignore::ignore::<&[u64]>(&table);
-  for i in 0u32..7u32
-  {
-    let t11: (&[u64], &[u64]) = table.split_at(i.wrapping_add(1u32).wrapping_mul(len) as usize);
-    let mut aM_copy0: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-    ((&mut aM_copy0)[0usize..len as usize]).copy_from_slice(&t11.1[0usize..len as usize]);
-    let ctx_n1: (&[u64], &[u64]) = ctx.split_at(0usize);
-    bn_almost_mont_sqr_u64(len, ctx_n1.1, mu, &aM_copy0, &mut tmp);
-    crate::lowstar::ignore::ignore::<&[u64]>(&ctx);
-    ((&mut (&mut table)[2u32.wrapping_mul(i).wrapping_add(2u32).wrapping_mul(len) as usize..])[0usize..len
-    as
-    usize]).copy_from_slice(&(&tmp)[0usize..len as usize]);
-    let t2: (&[u64], &[u64]) =
-        table.split_at(2u32.wrapping_mul(i).wrapping_add(2u32).wrapping_mul(len) as usize);
-    let mut aM_copy: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-    ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&aM)[0usize..len as usize]);
-    let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
-    bn_almost_mont_mul_u64(len, ctx_n.1, mu, &aM_copy, t2.1, &mut tmp);
-    crate::lowstar::ignore::ignore::<&[u64]>(&ctx);
-    ((&mut (&mut table)[2u32.wrapping_mul(i).wrapping_add(3u32).wrapping_mul(len) as usize..])[0usize..len
-    as
-    usize]).copy_from_slice(&(&tmp)[0usize..len as usize])
-  };
-  if bBits.wrapping_rem(4u32) != 0u32
-  {
-    let i: u32 = bBits.wrapping_div(4u32).wrapping_mul(4u32);
-    let bits_c: u64 = crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_bits_u64(bLen, b, i, 4u32);
-    let bits_l32: u32 = bits_c as u32;
-    let a_bits_l: (&[u64], &[u64]) = table.split_at(bits_l32.wrapping_mul(len) as usize);
-    ((&mut resM)[0usize..len as usize]).copy_from_slice(&a_bits_l.1[0usize..len as usize])
-  }
-  else
-  {
-    let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
-    let ctx_r2: (&[u64], &[u64]) = ctx_n.1.split_at(len as usize);
-    Hacl_Bignum_Montgomery_bn_from_mont_u64(len, ctx_r2.0, mu, ctx_r2.1, &mut resM);
-    crate::lowstar::ignore::ignore::<&[u64]>(&ctx)
-  };
-  let mut tmp0: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-  for i in 0u32..bBits.wrapping_div(4u32)
-  {
-    for i0 in 0u32..4u32
-    {
-      let mut aM_copy: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-      ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&resM)[0usize..len as usize]);
-      let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
-      bn_almost_mont_sqr_u64(len, ctx_n.1, mu, &aM_copy, &mut resM);
-      crate::lowstar::ignore::ignore::<&[u64]>(&ctx)
-    };
-    let k: u32 =
-        bBits.wrapping_sub(bBits.wrapping_rem(4u32)).wrapping_sub(4u32.wrapping_mul(i)).wrapping_sub(
-          4u32
-        );
-    let bits_l: u64 = crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_bits_u64(bLen, b, k, 4u32);
-    crate::lowstar::ignore::ignore::<&[u64]>(&table);
-    let bits_l32: u32 = bits_l as u32;
-    let a_bits_l: (&[u64], &[u64]) = table.split_at(bits_l32.wrapping_mul(len) as usize);
-    ((&mut tmp0)[0usize..len as usize]).copy_from_slice(&a_bits_l.1[0usize..len as usize]);
-    let mut aM_copy: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-    ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&resM)[0usize..len as usize]);
-    let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
-    bn_almost_mont_mul_u64(len, ctx_n.1, mu, &aM_copy, &tmp0, &mut resM);
-    crate::lowstar::ignore::ignore::<&[u64]>(&ctx)
-  };
-  Hacl_Bignum_Montgomery_bn_from_mont_u64(len, n, mu, &resM, res)
-}
-
-pub fn Hacl_Bignum_Exponentiation_bn_mod_exp_consttime_precomp_u64(
-  len: u32,
-  n: &[u64],
-  mu: u64,
-  r2: &[u64],
-  a: &[u64],
-  bBits: u32,
-  b: &[u64],
-  res: &mut [u64]
-)
-{
-  if bBits < 200u32
-  {
-    let mut aM: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-    Hacl_Bignum_Montgomery_bn_to_mont_u64(len, n, mu, r2, a, &mut aM);
-    let mut resM: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-    let mut ctx: Box<[u64]> = vec![0u64; len.wrapping_add(len) as usize].into_boxed_slice();
-    ((&mut ctx)[0usize..len as usize]).copy_from_slice(&n[0usize..len as usize]);
-    ((&mut (&mut ctx)[len as usize..])[0usize..len as usize]).copy_from_slice(
-      &r2[0usize..len as usize]
-    );
-    let mut sw: u64 = 0u64;
-    let ctx_n0: (&[u64], &[u64]) = ctx.split_at(0usize);
-    let ctx_r2: (&[u64], &[u64]) = ctx_n0.1.split_at(len as usize);
-    Hacl_Bignum_Montgomery_bn_from_mont_u64(len, ctx_r2.0, mu, ctx_r2.1, &mut resM);
-    crate::lowstar::ignore::ignore::<&[u64]>(&ctx);
-    for i0 in 0u32..bBits
-    {
-      let i1: u32 = bBits.wrapping_sub(i0).wrapping_sub(1u32).wrapping_div(64u32);
-      let j: u32 = bBits.wrapping_sub(i0).wrapping_sub(1u32).wrapping_rem(64u32);
-      let tmp: u64 = b[i1 as usize];
-      let bit: u64 = tmp.wrapping_shr(j) & 1u64;
-      let sw1: u64 = bit ^ sw;
-      for i in 0u32..len
-      {
-        let dummy: u64 = 0u64.wrapping_sub(sw1) & ((&resM)[i as usize] ^ (&aM)[i as usize]);
-        (&mut resM)[i as usize] = (&resM)[i as usize] ^ dummy;
-        (&mut aM)[i as usize] = (&aM)[i as usize] ^ dummy
-      };
-      let mut aM_copy: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-      ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&aM)[0usize..len as usize]);
-      let ctx_n1: (&[u64], &[u64]) = ctx.split_at(0usize);
-      bn_almost_mont_mul_u64(len, ctx_n1.1, mu, &aM_copy, &resM, &mut aM);
-      crate::lowstar::ignore::ignore::<&[u64]>(&ctx);
-      let mut aM_copy0: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-      ((&mut aM_copy0)[0usize..len as usize]).copy_from_slice(&(&resM)[0usize..len as usize]);
-      let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
-      bn_almost_mont_sqr_u64(len, ctx_n.1, mu, &aM_copy0, &mut resM);
-      crate::lowstar::ignore::ignore::<&[u64]>(&ctx);
-      sw = bit
-    };
-    let sw0: u64 = sw;
-    for i in 0u32..len
-    {
-      let dummy: u64 = 0u64.wrapping_sub(sw0) & ((&resM)[i as usize] ^ (&aM)[i as usize]);
-      (&mut resM)[i as usize] = (&resM)[i as usize] ^ dummy;
-      (&mut aM)[i as usize] = (&aM)[i as usize] ^ dummy
-    };
-    Hacl_Bignum_Montgomery_bn_from_mont_u64(len, n, mu, &resM, res);
-    return ()
-  };
-  let mut aM: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-  Hacl_Bignum_Montgomery_bn_to_mont_u64(len, n, mu, r2, a, &mut aM);
-  let mut resM: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-  let mut bLen: u32;
-  if bBits == 0u32
-  { bLen = 1u32 }
-  else
-  { bLen = bBits.wrapping_sub(1u32).wrapping_div(64u32).wrapping_add(1u32) };
-  let mut ctx: Box<[u64]> = vec![0u64; len.wrapping_add(len) as usize].into_boxed_slice();
-  ((&mut ctx)[0usize..len as usize]).copy_from_slice(&n[0usize..len as usize]);
-  ((&mut (&mut ctx)[len as usize..])[0usize..len as usize]).copy_from_slice(
-    &r2[0usize..len as usize]
-  );
-  let mut table: Box<[u64]> = vec![0u64; 16u32.wrapping_mul(len) as usize].into_boxed_slice();
-  let mut tmp: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-  let t0: (&mut [u64], &mut [u64]) = table.split_at_mut(0usize);
-  let t1: (&mut [u64], &mut [u64]) = t0.1.split_at_mut(len as usize);
-  let ctx_n0: (&[u64], &[u64]) = ctx.split_at(0usize);
-  let ctx_r20: (&[u64], &[u64]) = ctx_n0.1.split_at(len as usize);
-  Hacl_Bignum_Montgomery_bn_from_mont_u64(len, ctx_r20.0, mu, ctx_r20.1, t1.0);
-  crate::lowstar::ignore::ignore::<&[u64]>(&ctx);
-  (t1.1[0usize..len as usize]).copy_from_slice(&(&aM)[0usize..len as usize]);
-  crate::lowstar::ignore::ignore::<&[u64]>(&table);
-  for i in 0u32..7u32
-  {
-    let t11: (&[u64], &[u64]) = table.split_at(i.wrapping_add(1u32).wrapping_mul(len) as usize);
-    let mut aM_copy0: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-    ((&mut aM_copy0)[0usize..len as usize]).copy_from_slice(&t11.1[0usize..len as usize]);
-    let ctx_n1: (&[u64], &[u64]) = ctx.split_at(0usize);
-    bn_almost_mont_sqr_u64(len, ctx_n1.1, mu, &aM_copy0, &mut tmp);
-    crate::lowstar::ignore::ignore::<&[u64]>(&ctx);
-    ((&mut (&mut table)[2u32.wrapping_mul(i).wrapping_add(2u32).wrapping_mul(len) as usize..])[0usize..len
-    as
-    usize]).copy_from_slice(&(&tmp)[0usize..len as usize]);
-    let t2: (&[u64], &[u64]) =
-        table.split_at(2u32.wrapping_mul(i).wrapping_add(2u32).wrapping_mul(len) as usize);
-    let mut aM_copy: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-    ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&aM)[0usize..len as usize]);
-    let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
-    bn_almost_mont_mul_u64(len, ctx_n.1, mu, &aM_copy, t2.1, &mut tmp);
-    crate::lowstar::ignore::ignore::<&[u64]>(&ctx);
-    ((&mut (&mut table)[2u32.wrapping_mul(i).wrapping_add(3u32).wrapping_mul(len) as usize..])[0usize..len
-    as
-    usize]).copy_from_slice(&(&tmp)[0usize..len as usize])
-  };
-  if bBits.wrapping_rem(4u32) != 0u32
-  {
-    let i0: u32 = bBits.wrapping_div(4u32).wrapping_mul(4u32);
-    let bits_c: u64 = crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_bits_u64(bLen, b, i0, 4u32);
-    ((&mut resM)[0usize..len as usize]).copy_from_slice(
-      &(&(&table)[0u32.wrapping_mul(len) as usize..])[0usize..len as usize]
-    );
-    for i1 in 0u32..15u32
-    {
-      let c: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask(bits_c, i1.wrapping_add(1u32) as u64);
-      let res_j: (&[u64], &[u64]) =
-          table.split_at(i1.wrapping_add(1u32).wrapping_mul(len) as usize);
-      for i in 0u32..len
-      {
-        let x: u64 = c & res_j.1[i as usize] | ! c & (&resM)[i as usize];
-        let os: (&mut [u64], &mut [u64]) = resM.split_at_mut(0usize);
-        os.1[i as usize] = x
-      }
-    }
-  }
-  else
-  {
-    let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
-    let ctx_r2: (&[u64], &[u64]) = ctx_n.1.split_at(len as usize);
-    Hacl_Bignum_Montgomery_bn_from_mont_u64(len, ctx_r2.0, mu, ctx_r2.1, &mut resM);
-    crate::lowstar::ignore::ignore::<&[u64]>(&ctx)
-  };
-  let mut tmp0: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-  for i0 in 0u32..bBits.wrapping_div(4u32)
-  {
-    for i in 0u32..4u32
-    {
-      let mut aM_copy: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-      ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&resM)[0usize..len as usize]);
-      let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
-      bn_almost_mont_sqr_u64(len, ctx_n.1, mu, &aM_copy, &mut resM);
-      crate::lowstar::ignore::ignore::<&[u64]>(&ctx)
-    };
-    let k: u32 =
-        bBits.wrapping_sub(bBits.wrapping_rem(4u32)).wrapping_sub(4u32.wrapping_mul(i0)).wrapping_sub(
-          4u32
-        );
-    let bits_l: u64 = crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_bits_u64(bLen, b, k, 4u32);
-    crate::lowstar::ignore::ignore::<&[u64]>(&table);
-    ((&mut tmp0)[0usize..len as usize]).copy_from_slice(
-      &(&(&table)[0u32.wrapping_mul(len) as usize..])[0usize..len as usize]
-    );
-    for i1 in 0u32..15u32
-    {
-      let c: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask(bits_l, i1.wrapping_add(1u32) as u64);
-      let res_j: (&[u64], &[u64]) =
-          table.split_at(i1.wrapping_add(1u32).wrapping_mul(len) as usize);
-      for i in 0u32..len
-      {
-        let x: u64 = c & res_j.1[i as usize] | ! c & (&tmp0)[i as usize];
-        let os: (&mut [u64], &mut [u64]) = tmp0.split_at_mut(0usize);
-        os.1[i as usize] = x
-      }
-    };
-    let mut aM_copy: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-    ((&mut aM_copy)[0usize..len as usize]).copy_from_slice(&(&resM)[0usize..len as usize]);
-    let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
-    bn_almost_mont_mul_u64(len, ctx_n.1, mu, &aM_copy, &tmp0, &mut resM);
-    crate::lowstar::ignore::ignore::<&[u64]>(&ctx)
-  };
-  Hacl_Bignum_Montgomery_bn_from_mont_u64(len, n, mu, &resM, res)
-}
-
-pub fn Hacl_Bignum_Exponentiation_bn_mod_exp_vartime_u64(
-  len: u32,
-  nBits: u32,
-  n: &[u64],
-  a: &[u64],
-  bBits: u32,
-  b: &[u64],
-  res: &mut [u64]
-)
-{
-  let mut r2: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-  Hacl_Bignum_Montgomery_bn_precomp_r2_mod_n_u64(len, nBits, n, &mut r2);
-  let mu: u64 = Hacl_Bignum_ModInvLimb_mod_inv_uint64(n[0usize]);
-  Hacl_Bignum_Exponentiation_bn_mod_exp_vartime_precomp_u64(len, n, mu, &r2, a, bBits, b, res)
-}
-
-pub fn Hacl_Bignum_Exponentiation_bn_mod_exp_consttime_u64(
-  len: u32,
-  nBits: u32,
-  n: &[u64],
-  a: &[u64],
-  bBits: u32,
-  b: &[u64],
-  res: &mut [u64]
-)
-{
-  let mut r2: Box<[u64]> = vec![0u64; len as usize].into_boxed_slice();
-  Hacl_Bignum_Montgomery_bn_precomp_r2_mod_n_u64(len, nBits, n, &mut r2);
-  let mu: u64 = Hacl_Bignum_ModInvLimb_mod_inv_uint64(n[0usize]);
-  Hacl_Bignum_Exponentiation_bn_mod_exp_consttime_precomp_u64(len, n, mu, &r2, a, bBits, b, res)
 }

--- a/out/hacl/src/hacl/bignum4096.rs
+++ b/out/hacl/src/hacl/bignum4096.rs
@@ -29,31 +29,6 @@ pub fn Hacl_Bignum4096_add(a: &[u64], b: &[u64], res: &mut [u64]) -> u64
   return c
 }
 
-pub fn Hacl_Bignum4096_sub(a: &[u64], b: &[u64], res: &mut [u64]) -> u64
-{
-  let mut c: u64 = 0u64;
-  for i in 0u32..16u32
-  {
-    let t1: u64 = a[4u32.wrapping_mul(i) as usize];
-    let t20: u64 = b[4u32.wrapping_mul(i) as usize];
-    let res_i0: (&mut [u64], &mut [u64]) = res.split_at_mut(4u32.wrapping_mul(i) as usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, t20, res_i0.1);
-    let t10: u64 = a[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
-    let t21: u64 = b[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
-    let res_i1: (&mut [u64], &mut [u64]) = res_i0.1.split_at_mut(1usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t10, t21, res_i1.1);
-    let t11: u64 = a[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
-    let t22: u64 = b[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
-    let res_i2: (&mut [u64], &mut [u64]) = res_i1.1.split_at_mut(1usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t11, t22, res_i2.1);
-    let t12: u64 = a[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
-    let t2: u64 = b[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
-    let res_i: (&mut [u64], &mut [u64]) = res_i2.1.split_at_mut(1usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t12, t2, res_i.1)
-  };
-  return c
-}
-
 pub fn Hacl_Bignum4096_add_mod(n: &[u64], a: &[u64], b: &[u64], res: &mut [u64])
 {
   let mut c0: u64 = 0u64;
@@ -106,6 +81,415 @@ pub fn Hacl_Bignum4096_add_mod(n: &[u64], a: &[u64], b: &[u64], res: &mut [u64])
     let os: (&mut [u64], &mut [u64]) = res.split_at_mut(0usize);
     os.1[i as usize] = x
   }
+}
+
+pub fn Hacl_Bignum4096_bn_to_bytes_be(b: &[u64], res: &mut [u8])
+{
+  let tmp: [u8; 512] = [0u8; 512usize];
+  crate::lowstar::ignore::ignore::<[u8; 512]>(tmp);
+  for i in 0u32..64u32
+  {
+    crate::lowstar_endianness::store64_be(
+      &mut res[i.wrapping_mul(8u32) as usize..],
+      b[64u32.wrapping_sub(i).wrapping_sub(1u32) as usize]
+    )
+  }
+}
+
+pub fn Hacl_Bignum4096_bn_to_bytes_le(b: &[u64], res: &mut [u8])
+{
+  let tmp: [u8; 512] = [0u8; 512usize];
+  crate::lowstar::ignore::ignore::<[u8; 512]>(tmp);
+  for i in 0u32..64u32
+  {
+    crate::lowstar_endianness::store64_le(&mut res[i.wrapping_mul(8u32) as usize..], b[i as usize])
+  }
+}
+
+pub fn Hacl_Bignum4096_eq_mask(a: &[u64], b: &[u64]) -> u64
+{
+  let mut mask: u64 = 18446744073709551615u64;
+  for i in 0u32..64u32
+  {
+    let uu____0: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask(a[i as usize], b[i as usize]);
+    mask = uu____0 & mask
+  };
+  let mask1: u64 = mask;
+  return mask1
+}
+
+pub fn Hacl_Bignum4096_lt_mask(a: &[u64], b: &[u64]) -> u64
+{
+  let mut acc: u64 = 0u64;
+  for i in 0u32..64u32
+  {
+    let beq: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask(a[i as usize], b[i as usize]);
+    let blt: u64 = ! crate::hacl_krmllib::FStar_UInt64_gte_mask(a[i as usize], b[i as usize]);
+    acc = beq & acc | ! beq & blt
+  };
+  return acc
+}
+
+pub fn Hacl_Bignum4096_mod(n: &[u64], a: &[u64], res: &mut [u64]) -> bool
+{
+  let mut one: [u64; 64] = [0u64; 64usize];
+  (&mut one)[0usize] = 1u64;
+  let bit0: u64 = n[0usize] & 1u64;
+  let m0: u64 = 0u64.wrapping_sub(bit0);
+  let mut acc: u64 = 0u64;
+  for i in 0u32..64u32
+  {
+    let beq: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask((&one)[i as usize], n[i as usize]);
+    let blt: u64 = ! crate::hacl_krmllib::FStar_UInt64_gte_mask((&one)[i as usize], n[i as usize]);
+    acc = beq & acc | ! beq & blt
+  };
+  let m1: u64 = acc;
+  let is_valid_m: u64 = m0 & m1;
+  let nBits: u32 =
+      64u32.wrapping_mul(
+        crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_top_index_u64(64u32, n) as u32
+      );
+  if is_valid_m == 18446744073709551615u64
+  {
+    let mut r2: [u64; 64] = [0u64; 64usize];
+    precompr2(nBits, n, &mut r2);
+    let mu: u64 = crate::hacl::bignum::Hacl_Bignum_ModInvLimb_mod_inv_uint64(n[0usize]);
+    bn_slow_precomp(n, mu, &r2, a, res)
+  }
+  else
+  { (res[0usize..64usize]).copy_from_slice(&[0u64; 64usize]) };
+  return is_valid_m == 18446744073709551615u64
+}
+
+pub fn Hacl_Bignum4096_mod_exp_consttime(
+  n: &[u64],
+  a: &[u64],
+  bBits: u32,
+  b: &[u64],
+  res: &mut [u64]
+) ->
+    bool
+{
+  let is_valid_m: u64 = exp_check(n, a, bBits, b);
+  let nBits: u32 =
+      64u32.wrapping_mul(
+        crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_top_index_u64(64u32, n) as u32
+      );
+  if is_valid_m == 18446744073709551615u64
+  { exp_consttime(nBits, n, a, bBits, b, res) }
+  else
+  { (res[0usize..64usize]).copy_from_slice(&[0u64; 64usize]) };
+  return is_valid_m == 18446744073709551615u64
+}
+
+pub fn Hacl_Bignum4096_mod_exp_consttime_precomp(
+  k: &[crate::hacl::bignum::Hacl_Bignum_MontArithmetic_bn_mont_ctx_u64],
+  a: &[u64],
+  bBits: u32,
+  b: &[u64],
+  res: &mut [u64]
+)
+{
+  let n: &[u64] = &(k[0usize]).n;
+  let mu: u64 = (k[0usize]).mu;
+  let r2: &[u64] = &(k[0usize]).r2;
+  exp_consttime_precomp(n, mu, r2, a, bBits, b, res)
+}
+
+pub fn Hacl_Bignum4096_mod_exp_vartime(
+  n: &[u64],
+  a: &[u64],
+  bBits: u32,
+  b: &[u64],
+  res: &mut [u64]
+) ->
+    bool
+{
+  let is_valid_m: u64 = exp_check(n, a, bBits, b);
+  let nBits: u32 =
+      64u32.wrapping_mul(
+        crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_top_index_u64(64u32, n) as u32
+      );
+  if is_valid_m == 18446744073709551615u64
+  { exp_vartime(nBits, n, a, bBits, b, res) }
+  else
+  { (res[0usize..64usize]).copy_from_slice(&[0u64; 64usize]) };
+  return is_valid_m == 18446744073709551615u64
+}
+
+pub fn Hacl_Bignum4096_mod_exp_vartime_precomp(
+  k: &[crate::hacl::bignum::Hacl_Bignum_MontArithmetic_bn_mont_ctx_u64],
+  a: &[u64],
+  bBits: u32,
+  b: &[u64],
+  res: &mut [u64]
+)
+{
+  let n: &[u64] = &(k[0usize]).n;
+  let mu: u64 = (k[0usize]).mu;
+  let r2: &[u64] = &(k[0usize]).r2;
+  exp_vartime_precomp(n, mu, r2, a, bBits, b, res)
+}
+
+pub fn Hacl_Bignum4096_mod_inv_prime_vartime(n: &[u64], a: &[u64], res: &mut [u64]) -> bool
+{
+  let mut one: [u64; 64] = [0u64; 64usize];
+  (&mut one)[0usize] = 1u64;
+  let bit0: u64 = n[0usize] & 1u64;
+  let m0: u64 = 0u64.wrapping_sub(bit0);
+  let mut acc0: u64 = 0u64;
+  for i in 0u32..64u32
+  {
+    let beq: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask((&one)[i as usize], n[i as usize]);
+    let blt: u64 = ! crate::hacl_krmllib::FStar_UInt64_gte_mask((&one)[i as usize], n[i as usize]);
+    acc0 = beq & acc0 | ! beq & blt
+  };
+  let m1: u64 = acc0;
+  let m00: u64 = m0 & m1;
+  let bn_zero: [u64; 64] = [0u64; 64usize];
+  let mut mask: u64 = 18446744073709551615u64;
+  for i in 0u32..64u32
+  {
+    let uu____0: u64 =
+        crate::hacl_krmllib::FStar_UInt64_eq_mask(a[i as usize], bn_zero[i as usize]);
+    mask = uu____0 & mask
+  };
+  let mask1: u64 = mask;
+  let res10: u64 = mask1;
+  let m10: u64 = res10;
+  let mut acc: u64 = 0u64;
+  for i in 0u32..64u32
+  {
+    let beq: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask(a[i as usize], n[i as usize]);
+    let blt: u64 = ! crate::hacl_krmllib::FStar_UInt64_gte_mask(a[i as usize], n[i as usize]);
+    acc = beq & acc | ! beq & blt
+  };
+  let m2: u64 = acc;
+  let is_valid_m: u64 = m00 & ! m10 & m2;
+  let nBits: u32 =
+      64u32.wrapping_mul(
+        crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_top_index_u64(64u32, n) as u32
+      );
+  if is_valid_m == 18446744073709551615u64
+  {
+    let mut n2: [u64; 64] = [0u64; 64usize];
+    let c0: u64 =
+        crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(
+          0u64,
+          n[0usize],
+          2u64,
+          &mut n2
+        );
+    let a1: (&[u64], &[u64]) = n.split_at(1usize);
+    let res1: (&mut [u64], &mut [u64]) = n2.split_at_mut(1usize);
+    let mut c: u64 = c0;
+    for i in 0u32..15u32
+    {
+      let t1: u64 = a1.1[4u32.wrapping_mul(i) as usize];
+      let res_i0: (&mut [u64], &mut [u64]) = res1.1.split_at_mut(4u32.wrapping_mul(i) as usize);
+      c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, 0u64, res_i0.1);
+      let t10: u64 = a1.1[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
+      let res_i1: (&mut [u64], &mut [u64]) = res_i0.1.split_at_mut(1usize);
+      c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t10, 0u64, res_i1.1);
+      let t11: u64 = a1.1[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
+      let res_i2: (&mut [u64], &mut [u64]) = res_i1.1.split_at_mut(1usize);
+      c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t11, 0u64, res_i2.1);
+      let t12: u64 = a1.1[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
+      let res_i: (&mut [u64], &mut [u64]) = res_i2.1.split_at_mut(1usize);
+      c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t12, 0u64, res_i.1)
+    };
+    for i in 60u32..63u32
+    {
+      let t1: u64 = a1.1[i as usize];
+      let res_i: (&mut [u64], &mut [u64]) = res1.1.split_at_mut(i as usize);
+      c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, 0u64, res_i.1)
+    };
+    let c1: u64 = c;
+    let c2: u64 = c1;
+    crate::lowstar::ignore::ignore::<u64>(c2);
+    exp_vartime(nBits, n, a, 4096u32, &n2, res)
+  }
+  else
+  { (res[0usize..64usize]).copy_from_slice(&[0u64; 64usize]) };
+  return is_valid_m == 18446744073709551615u64
+}
+
+pub fn Hacl_Bignum4096_mod_inv_prime_vartime_precomp(
+  k: &[crate::hacl::bignum::Hacl_Bignum_MontArithmetic_bn_mont_ctx_u64],
+  a: &[u64],
+  res: &mut [u64]
+)
+{
+  let n: &[u64] = &(k[0usize]).n;
+  let mu: u64 = (k[0usize]).mu;
+  let r2: &[u64] = &(k[0usize]).r2;
+  let mut n2: [u64; 64] = [0u64; 64usize];
+  let c0: u64 =
+      crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(0u64, n[0usize], 2u64, &mut n2);
+  let a1: (&[u64], &[u64]) = n.split_at(1usize);
+  let res1: (&mut [u64], &mut [u64]) = n2.split_at_mut(1usize);
+  let mut c: u64 = c0;
+  for i in 0u32..15u32
+  {
+    let t1: u64 = a1.1[4u32.wrapping_mul(i) as usize];
+    let res_i0: (&mut [u64], &mut [u64]) = res1.1.split_at_mut(4u32.wrapping_mul(i) as usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, 0u64, res_i0.1);
+    let t10: u64 = a1.1[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
+    let res_i1: (&mut [u64], &mut [u64]) = res_i0.1.split_at_mut(1usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t10, 0u64, res_i1.1);
+    let t11: u64 = a1.1[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
+    let res_i2: (&mut [u64], &mut [u64]) = res_i1.1.split_at_mut(1usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t11, 0u64, res_i2.1);
+    let t12: u64 = a1.1[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
+    let res_i: (&mut [u64], &mut [u64]) = res_i2.1.split_at_mut(1usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t12, 0u64, res_i.1)
+  };
+  for i in 60u32..63u32
+  {
+    let t1: u64 = a1.1[i as usize];
+    let res_i: (&mut [u64], &mut [u64]) = res1.1.split_at_mut(i as usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, 0u64, res_i.1)
+  };
+  let c1: u64 = c;
+  let c2: u64 = c1;
+  crate::lowstar::ignore::ignore::<u64>(c2);
+  exp_vartime_precomp(n, mu, r2, a, 4096u32, &n2, res)
+}
+
+pub fn Hacl_Bignum4096_mod_precomp(
+  k: &[crate::hacl::bignum::Hacl_Bignum_MontArithmetic_bn_mont_ctx_u64],
+  a: &[u64],
+  res: &mut [u64]
+)
+{
+  let n: &[u64] = &(k[0usize]).n;
+  let mu: u64 = (k[0usize]).mu;
+  let r2: &[u64] = &(k[0usize]).r2;
+  bn_slow_precomp(n, mu, r2, a, res)
+}
+
+pub fn Hacl_Bignum4096_mont_ctx_free(
+  k: &[crate::hacl::bignum::Hacl_Bignum_MontArithmetic_bn_mont_ctx_u64]
+)
+{
+  let uu____0: &crate::hacl::bignum::Hacl_Bignum_MontArithmetic_bn_mont_ctx_u64 = &k[0usize];
+  let n: &[u64] = &uu____0.n;
+  let r2: &[u64] = &uu____0.r2;
+  ()
+}
+
+pub fn Hacl_Bignum4096_mont_ctx_init(n: &[u64]) ->
+    Box<[crate::hacl::bignum::Hacl_Bignum_MontArithmetic_bn_mont_ctx_u64]>
+{
+  let mut r2: Box<[u64]> = vec![0u64; 64usize].into_boxed_slice();
+  let mut n1: Box<[u64]> = vec![0u64; 64usize].into_boxed_slice();
+  let r21: (&mut [u64], &mut [u64]) = r2.split_at_mut(0usize);
+  let n11: (&mut [u64], &mut [u64]) = n1.split_at_mut(0usize);
+  (n11.1[0usize..64usize]).copy_from_slice(&n[0usize..64usize]);
+  let nBits: u32 =
+      64u32.wrapping_mul(
+        crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_top_index_u64(64u32, n) as u32
+      );
+  precompr2(nBits, n, r21.1);
+  let mu: u64 = crate::hacl::bignum::Hacl_Bignum_ModInvLimb_mod_inv_uint64(n[0usize]);
+  let res: crate::hacl::bignum::Hacl_Bignum_MontArithmetic_bn_mont_ctx_u64 =
+      crate::hacl::bignum::Hacl_Bignum_MontArithmetic_bn_mont_ctx_u64
+      { len: 64u32, n: (*n11.1).into(), mu, r2: (*r21.1).into() };
+  let buf: Box<[crate::hacl::bignum::Hacl_Bignum_MontArithmetic_bn_mont_ctx_u64]> =
+      vec![res].into_boxed_slice();
+  return buf
+}
+
+pub fn Hacl_Bignum4096_mul(a: &[u64], b: &[u64], res: &mut [u64])
+{
+  let mut tmp: [u64; 256] = [0u64; 256usize];
+  crate::hacl::bignum::Hacl_Bignum_Karatsuba_bn_karatsuba_mul_uint64(64u32, a, b, &mut tmp, res)
+}
+
+pub fn Hacl_Bignum4096_new_bn_from_bytes_be(len: u32, b: &[u8]) -> Box<[u64]>
+{
+  if len == 0u32 || len.wrapping_sub(1u32).wrapping_div(8u32).wrapping_add(1u32) > 536870911u32
+  { return [].into() };
+  let mut res: Box<[u64]> =
+      vec![0u64; len.wrapping_sub(1u32).wrapping_div(8u32).wrapping_add(1u32) as usize].into_boxed_slice(
+
+      );
+  let res1: (&mut [u64], &mut [u64]) = res.split_at_mut(0usize);
+  let res2: (&mut [u64], &mut [u64]) = res1.1.split_at_mut(0usize);
+  let bnLen: u32 = len.wrapping_sub(1u32).wrapping_div(8u32).wrapping_add(1u32);
+  let tmpLen: u32 = 8u32.wrapping_mul(bnLen);
+  let mut tmp: Box<[u8]> = vec![0u8; tmpLen as usize].into_boxed_slice();
+  ((&mut (&mut tmp)[tmpLen.wrapping_sub(len) as usize..])[0usize..len as usize]).copy_from_slice(
+    &b[0usize..len as usize]
+  );
+  for i in 0u32..bnLen
+  {
+    let u: u64 =
+        crate::lowstar_endianness::load64_be(
+          &(&tmp)[bnLen.wrapping_sub(i).wrapping_sub(1u32).wrapping_mul(8u32) as usize..]
+        );
+    let x: u64 = u;
+    let os: (&mut [u64], &mut [u64]) = res2.1.split_at_mut(0usize);
+    os.1[i as usize] = x
+  };
+  return (*res2.1).into()
+}
+
+pub fn Hacl_Bignum4096_new_bn_from_bytes_le(len: u32, b: &[u8]) -> Box<[u64]>
+{
+  if len == 0u32 || len.wrapping_sub(1u32).wrapping_div(8u32).wrapping_add(1u32) > 536870911u32
+  { return [].into() };
+  let mut res: Box<[u64]> =
+      vec![0u64; len.wrapping_sub(1u32).wrapping_div(8u32).wrapping_add(1u32) as usize].into_boxed_slice(
+
+      );
+  let res1: (&mut [u64], &mut [u64]) = res.split_at_mut(0usize);
+  let res2: (&mut [u64], &mut [u64]) = res1.1.split_at_mut(0usize);
+  let bnLen: u32 = len.wrapping_sub(1u32).wrapping_div(8u32).wrapping_add(1u32);
+  let tmpLen: u32 = 8u32.wrapping_mul(bnLen);
+  let mut tmp: Box<[u8]> = vec![0u8; tmpLen as usize].into_boxed_slice();
+  ((&mut tmp)[0usize..len as usize]).copy_from_slice(&b[0usize..len as usize]);
+  for i in 0u32..len.wrapping_sub(1u32).wrapping_div(8u32).wrapping_add(1u32)
+  {
+    let bj: (&[u8], &[u8]) = tmp.split_at(i.wrapping_mul(8u32) as usize);
+    let u: u64 = crate::lowstar_endianness::load64_le(bj.1);
+    let r1: u64 = u;
+    let x: u64 = r1;
+    let os: (&mut [u64], &mut [u64]) = res2.1.split_at_mut(0usize);
+    os.1[i as usize] = x
+  };
+  return (*res2.1).into()
+}
+
+pub fn Hacl_Bignum4096_sqr(a: &[u64], res: &mut [u64])
+{
+  let mut tmp: [u64; 256] = [0u64; 256usize];
+  crate::hacl::bignum::Hacl_Bignum_Karatsuba_bn_karatsuba_sqr_uint64(64u32, a, &mut tmp, res)
+}
+
+pub fn Hacl_Bignum4096_sub(a: &[u64], b: &[u64], res: &mut [u64]) -> u64
+{
+  let mut c: u64 = 0u64;
+  for i in 0u32..16u32
+  {
+    let t1: u64 = a[4u32.wrapping_mul(i) as usize];
+    let t20: u64 = b[4u32.wrapping_mul(i) as usize];
+    let res_i0: (&mut [u64], &mut [u64]) = res.split_at_mut(4u32.wrapping_mul(i) as usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, t20, res_i0.1);
+    let t10: u64 = a[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
+    let t21: u64 = b[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
+    let res_i1: (&mut [u64], &mut [u64]) = res_i0.1.split_at_mut(1usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t10, t21, res_i1.1);
+    let t11: u64 = a[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
+    let t22: u64 = b[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
+    let res_i2: (&mut [u64], &mut [u64]) = res_i1.1.split_at_mut(1usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t11, t22, res_i2.1);
+    let t12: u64 = a[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
+    let t2: u64 = b[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
+    let res_i: (&mut [u64], &mut [u64]) = res_i2.1.split_at_mut(1usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t12, t2, res_i.1)
+  };
+  return c
 }
 
 pub fn Hacl_Bignum4096_sub_mod(n: &[u64], a: &[u64], b: &[u64], res: &mut [u64])
@@ -163,108 +547,18 @@ pub fn Hacl_Bignum4096_sub_mod(n: &[u64], a: &[u64], b: &[u64], res: &mut [u64])
   }
 }
 
-pub fn Hacl_Bignum4096_mul(a: &[u64], b: &[u64], res: &mut [u64])
-{
-  let mut tmp: [u64; 256] = [0u64; 256usize];
-  crate::hacl::bignum::Hacl_Bignum_Karatsuba_bn_karatsuba_mul_uint64(64u32, a, b, &mut tmp, res)
-}
-
-pub fn Hacl_Bignum4096_sqr(a: &[u64], res: &mut [u64])
-{
-  let mut tmp: [u64; 256] = [0u64; 256usize];
-  crate::hacl::bignum::Hacl_Bignum_Karatsuba_bn_karatsuba_sqr_uint64(64u32, a, &mut tmp, res)
-}
-
-#[inline] pub fn precompr2(nBits: u32, n: &[u64], res: &mut [u64])
-{
-  (res[0usize..64usize]).copy_from_slice(&[0u64; 64usize]);
-  let i: u32 = nBits.wrapping_div(64u32);
-  let j: u32 = nBits.wrapping_rem(64u32);
-  res[i as usize] |= 1u64.wrapping_shl(j);
-  for i0 in 0u32..8192u32.wrapping_sub(nBits)
-  {
-    let mut a_copy: [u64; 64] = [0u64; 64usize];
-    let mut b_copy: [u64; 64] = [0u64; 64usize];
-    (a_copy[0usize..64usize]).copy_from_slice(&res[0usize..64usize]);
-    (b_copy[0usize..64usize]).copy_from_slice(&res[0usize..64usize]);
-    Hacl_Bignum4096_add_mod(n, &a_copy, &b_copy, res)
-  }
-}
-
-#[inline] pub fn reduction(n: &[u64], nInv: u64, c: &mut [u64], res: &mut [u64])
-{
-  let mut c0: u64 = 0u64;
-  for i0 in 0u32..64u32
-  {
-    let qj: u64 = nInv.wrapping_mul(c[i0 as usize]);
-    let res_j0: (&mut [u64], &mut [u64]) = c.split_at_mut(i0 as usize);
-    let mut c1: u64 = 0u64;
-    for i in 0u32..16u32
-    {
-      let a_i: u64 = n[4u32.wrapping_mul(i) as usize];
-      let res_i0: (&mut [u64], &mut [u64]) = res_j0.1.split_at_mut(4u32.wrapping_mul(i) as usize);
-      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c1, res_i0.1);
-      let a_i0: u64 = n[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
-      let res_i1: (&mut [u64], &mut [u64]) = res_i0.1.split_at_mut(1usize);
-      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, qj, c1, res_i1.1);
-      let a_i1: u64 = n[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
-      let res_i2: (&mut [u64], &mut [u64]) = res_i1.1.split_at_mut(1usize);
-      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, qj, c1, res_i2.1);
-      let a_i2: u64 = n[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
-      let res_i: (&mut [u64], &mut [u64]) = res_i2.1.split_at_mut(1usize);
-      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, qj, c1, res_i.1)
-    };
-    let r: u64 = c1;
-    let c10: u64 = r;
-    let res_j: u64 = c[64u32.wrapping_add(i0) as usize];
-    let resb: (&mut [u64], &mut [u64]) = c.split_at_mut(i0 as usize + 64usize);
-    c0 = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u64(c0, c10, res_j, resb.1)
-  };
-  (res[0usize..64usize]).copy_from_slice(&(&c[64usize..])[0usize..64usize]);
-  let c00: u64 = c0;
-  let mut tmp: [u64; 64] = [0u64; 64usize];
-  let mut c1: u64 = 0u64;
-  for i in 0u32..16u32
-  {
-    let t1: u64 = res[4u32.wrapping_mul(i) as usize];
-    let t20: u64 = n[4u32.wrapping_mul(i) as usize];
-    let res_i0: (&mut [u64], &mut [u64]) = tmp.split_at_mut(4u32.wrapping_mul(i) as usize);
-    c1 = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c1, t1, t20, res_i0.1);
-    let t10: u64 = res[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
-    let t21: u64 = n[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
-    let res_i1: (&mut [u64], &mut [u64]) = res_i0.1.split_at_mut(1usize);
-    c1 = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c1, t10, t21, res_i1.1);
-    let t11: u64 = res[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
-    let t22: u64 = n[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
-    let res_i2: (&mut [u64], &mut [u64]) = res_i1.1.split_at_mut(1usize);
-    c1 = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c1, t11, t22, res_i2.1);
-    let t12: u64 = res[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
-    let t2: u64 = n[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
-    let res_i: (&mut [u64], &mut [u64]) = res_i2.1.split_at_mut(1usize);
-    c1 = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c1, t12, t2, res_i.1)
-  };
-  let c10: u64 = c1;
-  let c2: u64 = c00.wrapping_sub(c10);
-  for i in 0u32..64u32
-  {
-    let x: u64 = c2 & res[i as usize] | ! c2 & tmp[i as usize];
-    let os: (&mut [u64], &mut [u64]) = res.split_at_mut(0usize);
-    os.1[i as usize] = x
-  }
-}
-
-#[inline] pub fn to(n: &[u64], nInv: u64, r2: &[u64], a: &[u64], aM: &mut [u64])
+#[inline] pub fn amont_mul(n: &[u64], nInv_u64: u64, aM: &[u64], bM: &[u64], resM: &mut [u64])
 {
   let mut c: [u64; 128] = [0u64; 128usize];
-  Hacl_Bignum4096_mul(a, r2, &mut c);
-  reduction(n, nInv, &mut c, aM)
+  Hacl_Bignum4096_mul(aM, bM, &mut c);
+  areduction(n, nInv_u64, &mut c, resM)
 }
 
-#[inline] pub fn from(n: &[u64], nInv_u64: u64, aM: &[u64], a: &mut [u64])
+#[inline] pub fn amont_sqr(n: &[u64], nInv_u64: u64, aM: &[u64], resM: &mut [u64])
 {
-  let mut tmp: [u64; 128] = [0u64; 128usize];
-  (tmp[0usize..64usize]).copy_from_slice(&aM[0usize..64usize]);
-  reduction(n, nInv_u64, &mut tmp, a)
+  let mut c: [u64; 128] = [0u64; 128usize];
+  Hacl_Bignum4096_sqr(aM, &mut c);
+  areduction(n, nInv_u64, &mut c, resM)
 }
 
 #[inline] pub fn areduction(n: &[u64], nInv: u64, c: &mut [u64], res: &mut [u64])
@@ -310,20 +604,6 @@ pub fn Hacl_Bignum4096_sqr(a: &[u64], res: &mut [u64])
   }
 }
 
-#[inline] pub fn amont_mul(n: &[u64], nInv_u64: u64, aM: &[u64], bM: &[u64], resM: &mut [u64])
-{
-  let mut c: [u64; 128] = [0u64; 128usize];
-  Hacl_Bignum4096_mul(aM, bM, &mut c);
-  areduction(n, nInv_u64, &mut c, resM)
-}
-
-#[inline] pub fn amont_sqr(n: &[u64], nInv_u64: u64, aM: &[u64], resM: &mut [u64])
-{
-  let mut c: [u64; 128] = [0u64; 128usize];
-  Hacl_Bignum4096_sqr(aM, &mut c);
-  areduction(n, nInv_u64, &mut c, resM)
-}
-
 #[inline] pub fn bn_slow_precomp(n: &[u64], mu: u64, r2: &[u64], a: &[u64], res: &mut [u64])
 {
   let mut a_mod: [u64; 64] = [0u64; 64usize];
@@ -331,37 +611,6 @@ pub fn Hacl_Bignum4096_sqr(a: &[u64], res: &mut [u64])
   (a1[0usize..128usize]).copy_from_slice(&a[0usize..128usize]);
   areduction(n, mu, &mut a1, &mut a_mod);
   to(n, mu, r2, &a_mod, res)
-}
-
-pub fn Hacl_Bignum4096_mod(n: &[u64], a: &[u64], res: &mut [u64]) -> bool
-{
-  let mut one: [u64; 64] = [0u64; 64usize];
-  (&mut one)[0usize] = 1u64;
-  let bit0: u64 = n[0usize] & 1u64;
-  let m0: u64 = 0u64.wrapping_sub(bit0);
-  let mut acc: u64 = 0u64;
-  for i in 0u32..64u32
-  {
-    let beq: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask((&one)[i as usize], n[i as usize]);
-    let blt: u64 = ! crate::hacl_krmllib::FStar_UInt64_gte_mask((&one)[i as usize], n[i as usize]);
-    acc = beq & acc | ! beq & blt
-  };
-  let m1: u64 = acc;
-  let is_valid_m: u64 = m0 & m1;
-  let nBits: u32 =
-      64u32.wrapping_mul(
-        crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_top_index_u64(64u32, n) as u32
-      );
-  if is_valid_m == 18446744073709551615u64
-  {
-    let mut r2: [u64; 64] = [0u64; 64usize];
-    precompr2(nBits, n, &mut r2);
-    let mu: u64 = crate::hacl::bignum::Hacl_Bignum_ModInvLimb_mod_inv_uint64(n[0usize]);
-    bn_slow_precomp(n, mu, &r2, a, res)
-  }
-  else
-  { (res[0usize..64usize]).copy_from_slice(&[0u64; 64usize]) };
-  return is_valid_m == 18446744073709551615u64
 }
 
 pub fn exp_check(n: &[u64], a: &[u64], bBits: u32, b: &[u64]) -> u64
@@ -415,136 +664,19 @@ pub fn exp_check(n: &[u64], a: &[u64], bBits: u32, b: &[u64]) -> u64
   return m00 & m
 }
 
-#[inline] pub fn exp_vartime_precomp(
+#[inline] pub fn exp_consttime(
+  nBits: u32,
   n: &[u64],
-  mu: u64,
-  r2: &[u64],
   a: &[u64],
   bBits: u32,
   b: &[u64],
   res: &mut [u64]
 )
 {
-  if bBits < 200u32
-  {
-    let mut aM: [u64; 64] = [0u64; 64usize];
-    to(n, mu, r2, a, &mut aM);
-    let mut resM: [u64; 64] = [0u64; 64usize];
-    let mut ctx: [u64; 128] = [0u64; 128usize];
-    (ctx[0usize..64usize]).copy_from_slice(&n[0usize..64usize]);
-    ((&mut ctx[64usize..])[0usize..64usize]).copy_from_slice(&r2[0usize..64usize]);
-    let ctx_n0: (&[u64], &[u64]) = ctx.split_at(0usize);
-    let ctx_r2: (&[u64], &[u64]) = ctx_n0.1.split_at(64usize);
-    from(ctx_r2.0, mu, ctx_r2.1, &mut resM);
-    crate::lowstar::ignore::ignore::<[u64; 128]>(ctx);
-    for i in 0u32..bBits
-    {
-      let i1: u32 = i.wrapping_div(64u32);
-      let j: u32 = i.wrapping_rem(64u32);
-      let tmp: u64 = b[i1 as usize];
-      let bit: u64 = tmp.wrapping_shr(j) & 1u64;
-      if bit != 0u64
-      {
-        let mut aM_copy: [u64; 64] = [0u64; 64usize];
-        (aM_copy[0usize..64usize]).copy_from_slice(&resM[0usize..64usize]);
-        let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
-        amont_mul(ctx_n.1, mu, &aM_copy, &aM, &mut resM);
-        crate::lowstar::ignore::ignore::<[u64; 128]>(ctx)
-      };
-      let mut aM_copy: [u64; 64] = [0u64; 64usize];
-      (aM_copy[0usize..64usize]).copy_from_slice(&aM[0usize..64usize]);
-      let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
-      amont_sqr(ctx_n.1, mu, &aM_copy, &mut aM);
-      crate::lowstar::ignore::ignore::<[u64; 128]>(ctx)
-    };
-    from(n, mu, &resM, res);
-    return ()
-  };
-  let mut aM: [u64; 64] = [0u64; 64usize];
-  to(n, mu, r2, a, &mut aM);
-  let mut resM: [u64; 64] = [0u64; 64usize];
-  let mut bLen: u32;
-  if bBits == 0u32
-  { bLen = 1u32 }
-  else
-  { bLen = bBits.wrapping_sub(1u32).wrapping_div(64u32).wrapping_add(1u32) };
-  let mut ctx: [u64; 128] = [0u64; 128usize];
-  (ctx[0usize..64usize]).copy_from_slice(&n[0usize..64usize]);
-  ((&mut ctx[64usize..])[0usize..64usize]).copy_from_slice(&r2[0usize..64usize]);
-  let mut table: [u64; 1024] = [0u64; 1024usize];
-  let mut tmp: [u64; 64] = [0u64; 64usize];
-  let t0: (&mut [u64], &mut [u64]) = table.split_at_mut(0usize);
-  let t1: (&mut [u64], &mut [u64]) = t0.1.split_at_mut(64usize);
-  let ctx_n0: (&[u64], &[u64]) = ctx.split_at(0usize);
-  let ctx_r20: (&[u64], &[u64]) = ctx_n0.1.split_at(64usize);
-  from(ctx_r20.0, mu, ctx_r20.1, t1.0);
-  crate::lowstar::ignore::ignore::<[u64; 128]>(ctx);
-  (t1.1[0usize..64usize]).copy_from_slice(&aM[0usize..64usize]);
-  crate::lowstar::ignore::ignore::<[u64; 1024]>(table);
-  for i in 0u32..7u32
-  {
-    let t11: (&[u64], &[u64]) = table.split_at(i.wrapping_add(1u32).wrapping_mul(64u32) as usize);
-    let mut aM_copy0: [u64; 64] = [0u64; 64usize];
-    (aM_copy0[0usize..64usize]).copy_from_slice(&t11.1[0usize..64usize]);
-    let ctx_n1: (&[u64], &[u64]) = ctx.split_at(0usize);
-    amont_sqr(ctx_n1.1, mu, &aM_copy0, &mut tmp);
-    crate::lowstar::ignore::ignore::<[u64; 128]>(ctx);
-    ((&mut table[2u32.wrapping_mul(i).wrapping_add(2u32).wrapping_mul(64u32) as usize..])[0usize..64usize]).copy_from_slice(
-      &tmp[0usize..64usize]
-    );
-    let t2: (&[u64], &[u64]) =
-        table.split_at(2u32.wrapping_mul(i).wrapping_add(2u32).wrapping_mul(64u32) as usize);
-    let mut aM_copy: [u64; 64] = [0u64; 64usize];
-    (aM_copy[0usize..64usize]).copy_from_slice(&aM[0usize..64usize]);
-    let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
-    amont_mul(ctx_n.1, mu, &aM_copy, t2.1, &mut tmp);
-    crate::lowstar::ignore::ignore::<[u64; 128]>(ctx);
-    ((&mut table[2u32.wrapping_mul(i).wrapping_add(3u32).wrapping_mul(64u32) as usize..])[0usize..64usize]).copy_from_slice(
-      &tmp[0usize..64usize]
-    )
-  };
-  if bBits.wrapping_rem(4u32) != 0u32
-  {
-    let i: u32 = bBits.wrapping_div(4u32).wrapping_mul(4u32);
-    let bits_c: u64 = crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_bits_u64(bLen, b, i, 4u32);
-    let bits_l32: u32 = bits_c as u32;
-    let a_bits_l: (&[u64], &[u64]) = table.split_at(bits_l32.wrapping_mul(64u32) as usize);
-    (resM[0usize..64usize]).copy_from_slice(&a_bits_l.1[0usize..64usize])
-  }
-  else
-  {
-    let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
-    let ctx_r2: (&[u64], &[u64]) = ctx_n.1.split_at(64usize);
-    from(ctx_r2.0, mu, ctx_r2.1, &mut resM);
-    crate::lowstar::ignore::ignore::<[u64; 128]>(ctx)
-  };
-  let mut tmp0: [u64; 64] = [0u64; 64usize];
-  for i in 0u32..bBits.wrapping_div(4u32)
-  {
-    for i0 in 0u32..4u32
-    {
-      let mut aM_copy: [u64; 64] = [0u64; 64usize];
-      (aM_copy[0usize..64usize]).copy_from_slice(&resM[0usize..64usize]);
-      let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
-      amont_sqr(ctx_n.1, mu, &aM_copy, &mut resM);
-      crate::lowstar::ignore::ignore::<[u64; 128]>(ctx)
-    };
-    let k: u32 =
-        bBits.wrapping_sub(bBits.wrapping_rem(4u32)).wrapping_sub(4u32.wrapping_mul(i)).wrapping_sub(
-          4u32
-        );
-    let bits_l: u64 = crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_bits_u64(bLen, b, k, 4u32);
-    crate::lowstar::ignore::ignore::<[u64; 1024]>(table);
-    let bits_l32: u32 = bits_l as u32;
-    let a_bits_l: (&[u64], &[u64]) = table.split_at(bits_l32.wrapping_mul(64u32) as usize);
-    (tmp0[0usize..64usize]).copy_from_slice(&a_bits_l.1[0usize..64usize]);
-    let mut aM_copy: [u64; 64] = [0u64; 64usize];
-    (aM_copy[0usize..64usize]).copy_from_slice(&resM[0usize..64usize]);
-    let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
-    amont_mul(ctx_n.1, mu, &aM_copy, &tmp0, &mut resM);
-    crate::lowstar::ignore::ignore::<[u64; 128]>(ctx)
-  };
-  from(n, mu, &resM, res)
+  let mut r2: [u64; 64] = [0u64; 64usize];
+  precompr2(nBits, n, &mut r2);
+  let mu: u64 = crate::hacl::bignum::Hacl_Bignum_ModInvLimb_mod_inv_uint64(n[0usize]);
+  exp_consttime_precomp(n, mu, &r2, a, bBits, b, res)
 }
 
 #[inline] pub fn exp_consttime_precomp(
@@ -727,358 +859,226 @@ pub fn exp_check(n: &[u64], a: &[u64], bBits: u32, b: &[u64]) -> u64
   exp_vartime_precomp(n, mu, &r2, a, bBits, b, res)
 }
 
-#[inline] pub fn exp_consttime(
-  nBits: u32,
+#[inline] pub fn exp_vartime_precomp(
   n: &[u64],
+  mu: u64,
+  r2: &[u64],
   a: &[u64],
   bBits: u32,
   b: &[u64],
   res: &mut [u64]
 )
 {
-  let mut r2: [u64; 64] = [0u64; 64usize];
-  precompr2(nBits, n, &mut r2);
-  let mu: u64 = crate::hacl::bignum::Hacl_Bignum_ModInvLimb_mod_inv_uint64(n[0usize]);
-  exp_consttime_precomp(n, mu, &r2, a, bBits, b, res)
-}
-
-pub fn Hacl_Bignum4096_mod_exp_vartime(
-  n: &[u64],
-  a: &[u64],
-  bBits: u32,
-  b: &[u64],
-  res: &mut [u64]
-) ->
-    bool
-{
-  let is_valid_m: u64 = exp_check(n, a, bBits, b);
-  let nBits: u32 =
-      64u32.wrapping_mul(
-        crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_top_index_u64(64u32, n) as u32
-      );
-  if is_valid_m == 18446744073709551615u64
-  { exp_vartime(nBits, n, a, bBits, b, res) }
-  else
-  { (res[0usize..64usize]).copy_from_slice(&[0u64; 64usize]) };
-  return is_valid_m == 18446744073709551615u64
-}
-
-pub fn Hacl_Bignum4096_mod_exp_consttime(
-  n: &[u64],
-  a: &[u64],
-  bBits: u32,
-  b: &[u64],
-  res: &mut [u64]
-) ->
-    bool
-{
-  let is_valid_m: u64 = exp_check(n, a, bBits, b);
-  let nBits: u32 =
-      64u32.wrapping_mul(
-        crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_top_index_u64(64u32, n) as u32
-      );
-  if is_valid_m == 18446744073709551615u64
-  { exp_consttime(nBits, n, a, bBits, b, res) }
-  else
-  { (res[0usize..64usize]).copy_from_slice(&[0u64; 64usize]) };
-  return is_valid_m == 18446744073709551615u64
-}
-
-pub fn Hacl_Bignum4096_mod_inv_prime_vartime(n: &[u64], a: &[u64], res: &mut [u64]) -> bool
-{
-  let mut one: [u64; 64] = [0u64; 64usize];
-  (&mut one)[0usize] = 1u64;
-  let bit0: u64 = n[0usize] & 1u64;
-  let m0: u64 = 0u64.wrapping_sub(bit0);
-  let mut acc0: u64 = 0u64;
-  for i in 0u32..64u32
+  if bBits < 200u32
   {
-    let beq: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask((&one)[i as usize], n[i as usize]);
-    let blt: u64 = ! crate::hacl_krmllib::FStar_UInt64_gte_mask((&one)[i as usize], n[i as usize]);
-    acc0 = beq & acc0 | ! beq & blt
-  };
-  let m1: u64 = acc0;
-  let m00: u64 = m0 & m1;
-  let bn_zero: [u64; 64] = [0u64; 64usize];
-  let mut mask: u64 = 18446744073709551615u64;
-  for i in 0u32..64u32
-  {
-    let uu____0: u64 =
-        crate::hacl_krmllib::FStar_UInt64_eq_mask(a[i as usize], bn_zero[i as usize]);
-    mask = uu____0 & mask
-  };
-  let mask1: u64 = mask;
-  let res10: u64 = mask1;
-  let m10: u64 = res10;
-  let mut acc: u64 = 0u64;
-  for i in 0u32..64u32
-  {
-    let beq: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask(a[i as usize], n[i as usize]);
-    let blt: u64 = ! crate::hacl_krmllib::FStar_UInt64_gte_mask(a[i as usize], n[i as usize]);
-    acc = beq & acc | ! beq & blt
-  };
-  let m2: u64 = acc;
-  let is_valid_m: u64 = m00 & ! m10 & m2;
-  let nBits: u32 =
-      64u32.wrapping_mul(
-        crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_top_index_u64(64u32, n) as u32
-      );
-  if is_valid_m == 18446744073709551615u64
-  {
-    let mut n2: [u64; 64] = [0u64; 64usize];
-    let c0: u64 =
-        crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(
-          0u64,
-          n[0usize],
-          2u64,
-          &mut n2
-        );
-    let a1: (&[u64], &[u64]) = n.split_at(1usize);
-    let res1: (&mut [u64], &mut [u64]) = n2.split_at_mut(1usize);
-    let mut c: u64 = c0;
-    for i in 0u32..15u32
+    let mut aM: [u64; 64] = [0u64; 64usize];
+    to(n, mu, r2, a, &mut aM);
+    let mut resM: [u64; 64] = [0u64; 64usize];
+    let mut ctx: [u64; 128] = [0u64; 128usize];
+    (ctx[0usize..64usize]).copy_from_slice(&n[0usize..64usize]);
+    ((&mut ctx[64usize..])[0usize..64usize]).copy_from_slice(&r2[0usize..64usize]);
+    let ctx_n0: (&[u64], &[u64]) = ctx.split_at(0usize);
+    let ctx_r2: (&[u64], &[u64]) = ctx_n0.1.split_at(64usize);
+    from(ctx_r2.0, mu, ctx_r2.1, &mut resM);
+    crate::lowstar::ignore::ignore::<[u64; 128]>(ctx);
+    for i in 0u32..bBits
     {
-      let t1: u64 = a1.1[4u32.wrapping_mul(i) as usize];
-      let res_i0: (&mut [u64], &mut [u64]) = res1.1.split_at_mut(4u32.wrapping_mul(i) as usize);
-      c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, 0u64, res_i0.1);
-      let t10: u64 = a1.1[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
-      let res_i1: (&mut [u64], &mut [u64]) = res_i0.1.split_at_mut(1usize);
-      c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t10, 0u64, res_i1.1);
-      let t11: u64 = a1.1[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
-      let res_i2: (&mut [u64], &mut [u64]) = res_i1.1.split_at_mut(1usize);
-      c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t11, 0u64, res_i2.1);
-      let t12: u64 = a1.1[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
-      let res_i: (&mut [u64], &mut [u64]) = res_i2.1.split_at_mut(1usize);
-      c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t12, 0u64, res_i.1)
+      let i1: u32 = i.wrapping_div(64u32);
+      let j: u32 = i.wrapping_rem(64u32);
+      let tmp: u64 = b[i1 as usize];
+      let bit: u64 = tmp.wrapping_shr(j) & 1u64;
+      if bit != 0u64
+      {
+        let mut aM_copy: [u64; 64] = [0u64; 64usize];
+        (aM_copy[0usize..64usize]).copy_from_slice(&resM[0usize..64usize]);
+        let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
+        amont_mul(ctx_n.1, mu, &aM_copy, &aM, &mut resM);
+        crate::lowstar::ignore::ignore::<[u64; 128]>(ctx)
+      };
+      let mut aM_copy: [u64; 64] = [0u64; 64usize];
+      (aM_copy[0usize..64usize]).copy_from_slice(&aM[0usize..64usize]);
+      let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
+      amont_sqr(ctx_n.1, mu, &aM_copy, &mut aM);
+      crate::lowstar::ignore::ignore::<[u64; 128]>(ctx)
     };
-    for i in 60u32..63u32
-    {
-      let t1: u64 = a1.1[i as usize];
-      let res_i: (&mut [u64], &mut [u64]) = res1.1.split_at_mut(i as usize);
-      c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, 0u64, res_i.1)
-    };
-    let c1: u64 = c;
-    let c2: u64 = c1;
-    crate::lowstar::ignore::ignore::<u64>(c2);
-    exp_vartime(nBits, n, a, 4096u32, &n2, res)
-  }
+    from(n, mu, &resM, res);
+    return ()
+  };
+  let mut aM: [u64; 64] = [0u64; 64usize];
+  to(n, mu, r2, a, &mut aM);
+  let mut resM: [u64; 64] = [0u64; 64usize];
+  let mut bLen: u32;
+  if bBits == 0u32
+  { bLen = 1u32 }
   else
-  { (res[0usize..64usize]).copy_from_slice(&[0u64; 64usize]) };
-  return is_valid_m == 18446744073709551615u64
-}
-
-pub fn Hacl_Bignum4096_mont_ctx_init(n: &[u64]) ->
-    Box<[crate::hacl::bignum::Hacl_Bignum_MontArithmetic_bn_mont_ctx_u64]>
-{
-  let mut r2: Box<[u64]> = vec![0u64; 64usize].into_boxed_slice();
-  let mut n1: Box<[u64]> = vec![0u64; 64usize].into_boxed_slice();
-  let r21: (&mut [u64], &mut [u64]) = r2.split_at_mut(0usize);
-  let n11: (&mut [u64], &mut [u64]) = n1.split_at_mut(0usize);
-  (n11.1[0usize..64usize]).copy_from_slice(&n[0usize..64usize]);
-  let nBits: u32 =
-      64u32.wrapping_mul(
-        crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_top_index_u64(64u32, n) as u32
-      );
-  precompr2(nBits, n, r21.1);
-  let mu: u64 = crate::hacl::bignum::Hacl_Bignum_ModInvLimb_mod_inv_uint64(n[0usize]);
-  let res: crate::hacl::bignum::Hacl_Bignum_MontArithmetic_bn_mont_ctx_u64 =
-      crate::hacl::bignum::Hacl_Bignum_MontArithmetic_bn_mont_ctx_u64
-      { len: 64u32, n: (*n11.1).into(), mu, r2: (*r21.1).into() };
-  let buf: Box<[crate::hacl::bignum::Hacl_Bignum_MontArithmetic_bn_mont_ctx_u64]> =
-      vec![res].into_boxed_slice();
-  return buf
-}
-
-pub fn Hacl_Bignum4096_mont_ctx_free(
-  k: &[crate::hacl::bignum::Hacl_Bignum_MontArithmetic_bn_mont_ctx_u64]
-)
-{
-  let uu____0: &crate::hacl::bignum::Hacl_Bignum_MontArithmetic_bn_mont_ctx_u64 = &k[0usize];
-  let n: &[u64] = &uu____0.n;
-  let r2: &[u64] = &uu____0.r2;
-  ()
-}
-
-pub fn Hacl_Bignum4096_mod_precomp(
-  k: &[crate::hacl::bignum::Hacl_Bignum_MontArithmetic_bn_mont_ctx_u64],
-  a: &[u64],
-  res: &mut [u64]
-)
-{
-  let n: &[u64] = &(k[0usize]).n;
-  let mu: u64 = (k[0usize]).mu;
-  let r2: &[u64] = &(k[0usize]).r2;
-  bn_slow_precomp(n, mu, r2, a, res)
-}
-
-pub fn Hacl_Bignum4096_mod_exp_vartime_precomp(
-  k: &[crate::hacl::bignum::Hacl_Bignum_MontArithmetic_bn_mont_ctx_u64],
-  a: &[u64],
-  bBits: u32,
-  b: &[u64],
-  res: &mut [u64]
-)
-{
-  let n: &[u64] = &(k[0usize]).n;
-  let mu: u64 = (k[0usize]).mu;
-  let r2: &[u64] = &(k[0usize]).r2;
-  exp_vartime_precomp(n, mu, r2, a, bBits, b, res)
-}
-
-pub fn Hacl_Bignum4096_mod_exp_consttime_precomp(
-  k: &[crate::hacl::bignum::Hacl_Bignum_MontArithmetic_bn_mont_ctx_u64],
-  a: &[u64],
-  bBits: u32,
-  b: &[u64],
-  res: &mut [u64]
-)
-{
-  let n: &[u64] = &(k[0usize]).n;
-  let mu: u64 = (k[0usize]).mu;
-  let r2: &[u64] = &(k[0usize]).r2;
-  exp_consttime_precomp(n, mu, r2, a, bBits, b, res)
-}
-
-pub fn Hacl_Bignum4096_mod_inv_prime_vartime_precomp(
-  k: &[crate::hacl::bignum::Hacl_Bignum_MontArithmetic_bn_mont_ctx_u64],
-  a: &[u64],
-  res: &mut [u64]
-)
-{
-  let n: &[u64] = &(k[0usize]).n;
-  let mu: u64 = (k[0usize]).mu;
-  let r2: &[u64] = &(k[0usize]).r2;
-  let mut n2: [u64; 64] = [0u64; 64usize];
-  let c0: u64 =
-      crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(0u64, n[0usize], 2u64, &mut n2);
-  let a1: (&[u64], &[u64]) = n.split_at(1usize);
-  let res1: (&mut [u64], &mut [u64]) = n2.split_at_mut(1usize);
-  let mut c: u64 = c0;
-  for i in 0u32..15u32
+  { bLen = bBits.wrapping_sub(1u32).wrapping_div(64u32).wrapping_add(1u32) };
+  let mut ctx: [u64; 128] = [0u64; 128usize];
+  (ctx[0usize..64usize]).copy_from_slice(&n[0usize..64usize]);
+  ((&mut ctx[64usize..])[0usize..64usize]).copy_from_slice(&r2[0usize..64usize]);
+  let mut table: [u64; 1024] = [0u64; 1024usize];
+  let mut tmp: [u64; 64] = [0u64; 64usize];
+  let t0: (&mut [u64], &mut [u64]) = table.split_at_mut(0usize);
+  let t1: (&mut [u64], &mut [u64]) = t0.1.split_at_mut(64usize);
+  let ctx_n0: (&[u64], &[u64]) = ctx.split_at(0usize);
+  let ctx_r20: (&[u64], &[u64]) = ctx_n0.1.split_at(64usize);
+  from(ctx_r20.0, mu, ctx_r20.1, t1.0);
+  crate::lowstar::ignore::ignore::<[u64; 128]>(ctx);
+  (t1.1[0usize..64usize]).copy_from_slice(&aM[0usize..64usize]);
+  crate::lowstar::ignore::ignore::<[u64; 1024]>(table);
+  for i in 0u32..7u32
   {
-    let t1: u64 = a1.1[4u32.wrapping_mul(i) as usize];
-    let res_i0: (&mut [u64], &mut [u64]) = res1.1.split_at_mut(4u32.wrapping_mul(i) as usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, 0u64, res_i0.1);
-    let t10: u64 = a1.1[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
-    let res_i1: (&mut [u64], &mut [u64]) = res_i0.1.split_at_mut(1usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t10, 0u64, res_i1.1);
-    let t11: u64 = a1.1[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
-    let res_i2: (&mut [u64], &mut [u64]) = res_i1.1.split_at_mut(1usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t11, 0u64, res_i2.1);
-    let t12: u64 = a1.1[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
-    let res_i: (&mut [u64], &mut [u64]) = res_i2.1.split_at_mut(1usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t12, 0u64, res_i.1)
-  };
-  for i in 60u32..63u32
-  {
-    let t1: u64 = a1.1[i as usize];
-    let res_i: (&mut [u64], &mut [u64]) = res1.1.split_at_mut(i as usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, 0u64, res_i.1)
-  };
-  let c1: u64 = c;
-  let c2: u64 = c1;
-  crate::lowstar::ignore::ignore::<u64>(c2);
-  exp_vartime_precomp(n, mu, r2, a, 4096u32, &n2, res)
-}
-
-pub fn Hacl_Bignum4096_new_bn_from_bytes_be(len: u32, b: &[u8]) -> Box<[u64]>
-{
-  if len == 0u32 || len.wrapping_sub(1u32).wrapping_div(8u32).wrapping_add(1u32) > 536870911u32
-  { return [].into() };
-  let mut res: Box<[u64]> =
-      vec![0u64; len.wrapping_sub(1u32).wrapping_div(8u32).wrapping_add(1u32) as usize].into_boxed_slice(
-
-      );
-  let res1: (&mut [u64], &mut [u64]) = res.split_at_mut(0usize);
-  let res2: (&mut [u64], &mut [u64]) = res1.1.split_at_mut(0usize);
-  let bnLen: u32 = len.wrapping_sub(1u32).wrapping_div(8u32).wrapping_add(1u32);
-  let tmpLen: u32 = 8u32.wrapping_mul(bnLen);
-  let mut tmp: Box<[u8]> = vec![0u8; tmpLen as usize].into_boxed_slice();
-  ((&mut (&mut tmp)[tmpLen.wrapping_sub(len) as usize..])[0usize..len as usize]).copy_from_slice(
-    &b[0usize..len as usize]
-  );
-  for i in 0u32..bnLen
-  {
-    let u: u64 =
-        crate::lowstar_endianness::load64_be(
-          &(&tmp)[bnLen.wrapping_sub(i).wrapping_sub(1u32).wrapping_mul(8u32) as usize..]
-        );
-    let x: u64 = u;
-    let os: (&mut [u64], &mut [u64]) = res2.1.split_at_mut(0usize);
-    os.1[i as usize] = x
-  };
-  return (*res2.1).into()
-}
-
-pub fn Hacl_Bignum4096_new_bn_from_bytes_le(len: u32, b: &[u8]) -> Box<[u64]>
-{
-  if len == 0u32 || len.wrapping_sub(1u32).wrapping_div(8u32).wrapping_add(1u32) > 536870911u32
-  { return [].into() };
-  let mut res: Box<[u64]> =
-      vec![0u64; len.wrapping_sub(1u32).wrapping_div(8u32).wrapping_add(1u32) as usize].into_boxed_slice(
-
-      );
-  let res1: (&mut [u64], &mut [u64]) = res.split_at_mut(0usize);
-  let res2: (&mut [u64], &mut [u64]) = res1.1.split_at_mut(0usize);
-  let bnLen: u32 = len.wrapping_sub(1u32).wrapping_div(8u32).wrapping_add(1u32);
-  let tmpLen: u32 = 8u32.wrapping_mul(bnLen);
-  let mut tmp: Box<[u8]> = vec![0u8; tmpLen as usize].into_boxed_slice();
-  ((&mut tmp)[0usize..len as usize]).copy_from_slice(&b[0usize..len as usize]);
-  for i in 0u32..len.wrapping_sub(1u32).wrapping_div(8u32).wrapping_add(1u32)
-  {
-    let bj: (&[u8], &[u8]) = tmp.split_at(i.wrapping_mul(8u32) as usize);
-    let u: u64 = crate::lowstar_endianness::load64_le(bj.1);
-    let r1: u64 = u;
-    let x: u64 = r1;
-    let os: (&mut [u64], &mut [u64]) = res2.1.split_at_mut(0usize);
-    os.1[i as usize] = x
-  };
-  return (*res2.1).into()
-}
-
-pub fn Hacl_Bignum4096_bn_to_bytes_be(b: &[u64], res: &mut [u8])
-{
-  let tmp: [u8; 512] = [0u8; 512usize];
-  crate::lowstar::ignore::ignore::<[u8; 512]>(tmp);
-  for i in 0u32..64u32
-  {
-    crate::lowstar_endianness::store64_be(
-      &mut res[i.wrapping_mul(8u32) as usize..],
-      b[64u32.wrapping_sub(i).wrapping_sub(1u32) as usize]
+    let t11: (&[u64], &[u64]) = table.split_at(i.wrapping_add(1u32).wrapping_mul(64u32) as usize);
+    let mut aM_copy0: [u64; 64] = [0u64; 64usize];
+    (aM_copy0[0usize..64usize]).copy_from_slice(&t11.1[0usize..64usize]);
+    let ctx_n1: (&[u64], &[u64]) = ctx.split_at(0usize);
+    amont_sqr(ctx_n1.1, mu, &aM_copy0, &mut tmp);
+    crate::lowstar::ignore::ignore::<[u64; 128]>(ctx);
+    ((&mut table[2u32.wrapping_mul(i).wrapping_add(2u32).wrapping_mul(64u32) as usize..])[0usize..64usize]).copy_from_slice(
+      &tmp[0usize..64usize]
+    );
+    let t2: (&[u64], &[u64]) =
+        table.split_at(2u32.wrapping_mul(i).wrapping_add(2u32).wrapping_mul(64u32) as usize);
+    let mut aM_copy: [u64; 64] = [0u64; 64usize];
+    (aM_copy[0usize..64usize]).copy_from_slice(&aM[0usize..64usize]);
+    let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
+    amont_mul(ctx_n.1, mu, &aM_copy, t2.1, &mut tmp);
+    crate::lowstar::ignore::ignore::<[u64; 128]>(ctx);
+    ((&mut table[2u32.wrapping_mul(i).wrapping_add(3u32).wrapping_mul(64u32) as usize..])[0usize..64usize]).copy_from_slice(
+      &tmp[0usize..64usize]
     )
+  };
+  if bBits.wrapping_rem(4u32) != 0u32
+  {
+    let i: u32 = bBits.wrapping_div(4u32).wrapping_mul(4u32);
+    let bits_c: u64 = crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_bits_u64(bLen, b, i, 4u32);
+    let bits_l32: u32 = bits_c as u32;
+    let a_bits_l: (&[u64], &[u64]) = table.split_at(bits_l32.wrapping_mul(64u32) as usize);
+    (resM[0usize..64usize]).copy_from_slice(&a_bits_l.1[0usize..64usize])
+  }
+  else
+  {
+    let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
+    let ctx_r2: (&[u64], &[u64]) = ctx_n.1.split_at(64usize);
+    from(ctx_r2.0, mu, ctx_r2.1, &mut resM);
+    crate::lowstar::ignore::ignore::<[u64; 128]>(ctx)
+  };
+  let mut tmp0: [u64; 64] = [0u64; 64usize];
+  for i in 0u32..bBits.wrapping_div(4u32)
+  {
+    for i0 in 0u32..4u32
+    {
+      let mut aM_copy: [u64; 64] = [0u64; 64usize];
+      (aM_copy[0usize..64usize]).copy_from_slice(&resM[0usize..64usize]);
+      let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
+      amont_sqr(ctx_n.1, mu, &aM_copy, &mut resM);
+      crate::lowstar::ignore::ignore::<[u64; 128]>(ctx)
+    };
+    let k: u32 =
+        bBits.wrapping_sub(bBits.wrapping_rem(4u32)).wrapping_sub(4u32.wrapping_mul(i)).wrapping_sub(
+          4u32
+        );
+    let bits_l: u64 = crate::hacl::bignum_base::Hacl_Bignum_Lib_bn_get_bits_u64(bLen, b, k, 4u32);
+    crate::lowstar::ignore::ignore::<[u64; 1024]>(table);
+    let bits_l32: u32 = bits_l as u32;
+    let a_bits_l: (&[u64], &[u64]) = table.split_at(bits_l32.wrapping_mul(64u32) as usize);
+    (tmp0[0usize..64usize]).copy_from_slice(&a_bits_l.1[0usize..64usize]);
+    let mut aM_copy: [u64; 64] = [0u64; 64usize];
+    (aM_copy[0usize..64usize]).copy_from_slice(&resM[0usize..64usize]);
+    let ctx_n: (&[u64], &[u64]) = ctx.split_at(0usize);
+    amont_mul(ctx_n.1, mu, &aM_copy, &tmp0, &mut resM);
+    crate::lowstar::ignore::ignore::<[u64; 128]>(ctx)
+  };
+  from(n, mu, &resM, res)
+}
+
+#[inline] pub fn from(n: &[u64], nInv_u64: u64, aM: &[u64], a: &mut [u64])
+{
+  let mut tmp: [u64; 128] = [0u64; 128usize];
+  (tmp[0usize..64usize]).copy_from_slice(&aM[0usize..64usize]);
+  reduction(n, nInv_u64, &mut tmp, a)
+}
+
+#[inline] pub fn precompr2(nBits: u32, n: &[u64], res: &mut [u64])
+{
+  (res[0usize..64usize]).copy_from_slice(&[0u64; 64usize]);
+  let i: u32 = nBits.wrapping_div(64u32);
+  let j: u32 = nBits.wrapping_rem(64u32);
+  res[i as usize] |= 1u64.wrapping_shl(j);
+  for i0 in 0u32..8192u32.wrapping_sub(nBits)
+  {
+    let mut a_copy: [u64; 64] = [0u64; 64usize];
+    let mut b_copy: [u64; 64] = [0u64; 64usize];
+    (a_copy[0usize..64usize]).copy_from_slice(&res[0usize..64usize]);
+    (b_copy[0usize..64usize]).copy_from_slice(&res[0usize..64usize]);
+    Hacl_Bignum4096_add_mod(n, &a_copy, &b_copy, res)
   }
 }
 
-pub fn Hacl_Bignum4096_bn_to_bytes_le(b: &[u64], res: &mut [u8])
+#[inline] pub fn reduction(n: &[u64], nInv: u64, c: &mut [u64], res: &mut [u64])
 {
-  let tmp: [u8; 512] = [0u8; 512usize];
-  crate::lowstar::ignore::ignore::<[u8; 512]>(tmp);
+  let mut c0: u64 = 0u64;
+  for i0 in 0u32..64u32
+  {
+    let qj: u64 = nInv.wrapping_mul(c[i0 as usize]);
+    let res_j0: (&mut [u64], &mut [u64]) = c.split_at_mut(i0 as usize);
+    let mut c1: u64 = 0u64;
+    for i in 0u32..16u32
+    {
+      let a_i: u64 = n[4u32.wrapping_mul(i) as usize];
+      let res_i0: (&mut [u64], &mut [u64]) = res_j0.1.split_at_mut(4u32.wrapping_mul(i) as usize);
+      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c1, res_i0.1);
+      let a_i0: u64 = n[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
+      let res_i1: (&mut [u64], &mut [u64]) = res_i0.1.split_at_mut(1usize);
+      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, qj, c1, res_i1.1);
+      let a_i1: u64 = n[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
+      let res_i2: (&mut [u64], &mut [u64]) = res_i1.1.split_at_mut(1usize);
+      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, qj, c1, res_i2.1);
+      let a_i2: u64 = n[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
+      let res_i: (&mut [u64], &mut [u64]) = res_i2.1.split_at_mut(1usize);
+      c1 = crate::hacl::bignum_base::Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, qj, c1, res_i.1)
+    };
+    let r: u64 = c1;
+    let c10: u64 = r;
+    let res_j: u64 = c[64u32.wrapping_add(i0) as usize];
+    let resb: (&mut [u64], &mut [u64]) = c.split_at_mut(i0 as usize + 64usize);
+    c0 = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u64(c0, c10, res_j, resb.1)
+  };
+  (res[0usize..64usize]).copy_from_slice(&(&c[64usize..])[0usize..64usize]);
+  let c00: u64 = c0;
+  let mut tmp: [u64; 64] = [0u64; 64usize];
+  let mut c1: u64 = 0u64;
+  for i in 0u32..16u32
+  {
+    let t1: u64 = res[4u32.wrapping_mul(i) as usize];
+    let t20: u64 = n[4u32.wrapping_mul(i) as usize];
+    let res_i0: (&mut [u64], &mut [u64]) = tmp.split_at_mut(4u32.wrapping_mul(i) as usize);
+    c1 = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c1, t1, t20, res_i0.1);
+    let t10: u64 = res[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
+    let t21: u64 = n[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
+    let res_i1: (&mut [u64], &mut [u64]) = res_i0.1.split_at_mut(1usize);
+    c1 = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c1, t10, t21, res_i1.1);
+    let t11: u64 = res[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
+    let t22: u64 = n[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
+    let res_i2: (&mut [u64], &mut [u64]) = res_i1.1.split_at_mut(1usize);
+    c1 = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c1, t11, t22, res_i2.1);
+    let t12: u64 = res[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
+    let t2: u64 = n[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
+    let res_i: (&mut [u64], &mut [u64]) = res_i2.1.split_at_mut(1usize);
+    c1 = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_sub_borrow_u64(c1, t12, t2, res_i.1)
+  };
+  let c10: u64 = c1;
+  let c2: u64 = c00.wrapping_sub(c10);
   for i in 0u32..64u32
   {
-    crate::lowstar_endianness::store64_le(&mut res[i.wrapping_mul(8u32) as usize..], b[i as usize])
+    let x: u64 = c2 & res[i as usize] | ! c2 & tmp[i as usize];
+    let os: (&mut [u64], &mut [u64]) = res.split_at_mut(0usize);
+    os.1[i as usize] = x
   }
 }
 
-pub fn Hacl_Bignum4096_lt_mask(a: &[u64], b: &[u64]) -> u64
+#[inline] pub fn to(n: &[u64], nInv: u64, r2: &[u64], a: &[u64], aM: &mut [u64])
 {
-  let mut acc: u64 = 0u64;
-  for i in 0u32..64u32
-  {
-    let beq: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask(a[i as usize], b[i as usize]);
-    let blt: u64 = ! crate::hacl_krmllib::FStar_UInt64_gte_mask(a[i as usize], b[i as usize]);
-    acc = beq & acc | ! beq & blt
-  };
-  return acc
-}
-
-pub fn Hacl_Bignum4096_eq_mask(a: &[u64], b: &[u64]) -> u64
-{
-  let mut mask: u64 = 18446744073709551615u64;
-  for i in 0u32..64u32
-  {
-    let uu____0: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask(a[i as usize], b[i as usize]);
-    mask = uu____0 & mask
-  };
-  let mask1: u64 = mask;
-  return mask1
+  let mut c: [u64; 128] = [0u64; 128usize];
+  Hacl_Bignum4096_mul(a, r2, &mut c);
+  reduction(n, nInv, &mut c, aM)
 }

--- a/out/hacl/src/hacl/bignum_base.rs
+++ b/out/hacl/src/hacl/bignum_base.rs
@@ -4,122 +4,80 @@
 #![allow(unused_assignments)]
 #![allow(unreachable_patterns)]
 
-#[inline] pub fn Hacl_Bignum_Base_mul_wide_add2_u32(a: u32, b: u32, c_in: u32, out: &mut [u32]) ->
+#[inline] pub fn Hacl_Bignum_Addition_bn_add_eq_len_u32(
+  aLen: u32,
+  a: &[u32],
+  b: &[u32],
+  res: &mut [u32]
+) ->
     u32
 {
-  let out0: u32 = out[0usize];
-  let res: u64 =
-      (a as u64).wrapping_mul(b as u64).wrapping_add(c_in as u64).wrapping_add(out0 as u64);
-  out[0usize] = res as u32;
-  return res.wrapping_shr(32u32) as u32
+  let mut c: u32 = 0u32;
+  for i in 0u32..aLen.wrapping_div(4u32)
+  {
+    let t1: u32 = a[4u32.wrapping_mul(i) as usize];
+    let t20: u32 = b[4u32.wrapping_mul(i) as usize];
+    let res_i0: (&mut [u32], &mut [u32]) = res.split_at_mut(4u32.wrapping_mul(i) as usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u32(c, t1, t20, res_i0.1);
+    let t10: u32 = a[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
+    let t21: u32 = b[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
+    let res_i1: (&mut [u32], &mut [u32]) = res_i0.1.split_at_mut(1usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u32(c, t10, t21, res_i1.1);
+    let t11: u32 = a[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
+    let t22: u32 = b[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
+    let res_i2: (&mut [u32], &mut [u32]) = res_i1.1.split_at_mut(1usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u32(c, t11, t22, res_i2.1);
+    let t12: u32 = a[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
+    let t2: u32 = b[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
+    let res_i: (&mut [u32], &mut [u32]) = res_i2.1.split_at_mut(1usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u32(c, t12, t2, res_i.1)
+  };
+  for i in aLen.wrapping_div(4u32).wrapping_mul(4u32)..aLen
+  {
+    let t1: u32 = a[i as usize];
+    let t2: u32 = b[i as usize];
+    let res_i: (&mut [u32], &mut [u32]) = res.split_at_mut(i as usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u32(c, t1, t2, res_i.1)
+  };
+  return c
 }
 
-#[inline] pub fn Hacl_Bignum_Base_mul_wide_add2_u64(a: u64, b: u64, c_in: u64, out: &mut [u64]) ->
+#[inline] pub fn Hacl_Bignum_Addition_bn_add_eq_len_u64(
+  aLen: u32,
+  a: &[u64],
+  b: &[u64],
+  res: &mut [u64]
+) ->
     u64
 {
-  let out0: u64 = out[0usize];
-  let res: crate::types::FStar_UInt128_uint128 =
-      crate::hacl_krmllib::FStar_UInt128_add(
-        crate::hacl_krmllib::FStar_UInt128_add(
-          crate::hacl_krmllib::FStar_UInt128_mul_wide(a, b),
-          crate::hacl_krmllib::FStar_UInt128_uint64_to_uint128(c_in)
-        ),
-        crate::hacl_krmllib::FStar_UInt128_uint64_to_uint128(out0)
-      );
-  out[0usize] = crate::hacl_krmllib::FStar_UInt128_uint128_to_uint64(res);
-  return
-  crate::hacl_krmllib::FStar_UInt128_uint128_to_uint64(
-    crate::hacl_krmllib::FStar_UInt128_shift_right(res, 64u32)
-  )
-}
-
-#[inline] pub fn Hacl_Bignum_Convert_bn_from_bytes_be_uint64(
-  len: u32,
-  b: &[u8],
-  res: &mut [u64]
-)
-{
-  let bnLen: u32 = len.wrapping_sub(1u32).wrapping_div(8u32).wrapping_add(1u32);
-  let tmpLen: u32 = 8u32.wrapping_mul(bnLen);
-  let mut tmp: Box<[u8]> = vec![0u8; tmpLen as usize].into_boxed_slice();
-  ((&mut (&mut tmp)[tmpLen.wrapping_sub(len) as usize..])[0usize..len as usize]).copy_from_slice(
-    &b[0usize..len as usize]
-  );
-  for i in 0u32..bnLen
+  let mut c: u64 = 0u64;
+  for i in 0u32..aLen.wrapping_div(4u32)
   {
-    let u: u64 =
-        crate::lowstar_endianness::load64_be(
-          &(&tmp)[bnLen.wrapping_sub(i).wrapping_sub(1u32).wrapping_mul(8u32) as usize..]
-        );
-    let x: u64 = u;
-    let os: (&mut [u64], &mut [u64]) = res.split_at_mut(0usize);
-    os.1[i as usize] = x
-  }
-}
-
-#[inline] pub fn Hacl_Bignum_Convert_bn_to_bytes_be_uint64(len: u32, b: &[u64], res: &mut [u8])
-{
-  let bnLen: u32 = len.wrapping_sub(1u32).wrapping_div(8u32).wrapping_add(1u32);
-  let tmpLen: u32 = 8u32.wrapping_mul(bnLen);
-  let mut tmp: Box<[u8]> = vec![0u8; tmpLen as usize].into_boxed_slice();
-  for i in 0u32..bnLen
-  {
-    crate::lowstar_endianness::store64_be(
-      &mut (&mut tmp)[i.wrapping_mul(8u32) as usize..],
-      b[bnLen.wrapping_sub(i).wrapping_sub(1u32) as usize]
-    )
+    let t1: u64 = a[4u32.wrapping_mul(i) as usize];
+    let t20: u64 = b[4u32.wrapping_mul(i) as usize];
+    let res_i0: (&mut [u64], &mut [u64]) = res.split_at_mut(4u32.wrapping_mul(i) as usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t20, res_i0.1);
+    let t10: u64 = a[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
+    let t21: u64 = b[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
+    let res_i1: (&mut [u64], &mut [u64]) = res_i0.1.split_at_mut(1usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u64(c, t10, t21, res_i1.1);
+    let t11: u64 = a[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
+    let t22: u64 = b[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
+    let res_i2: (&mut [u64], &mut [u64]) = res_i1.1.split_at_mut(1usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u64(c, t11, t22, res_i2.1);
+    let t12: u64 = a[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
+    let t2: u64 = b[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
+    let res_i: (&mut [u64], &mut [u64]) = res_i2.1.split_at_mut(1usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i.1)
   };
-  (res[0usize..len as usize]).copy_from_slice(
-    &(&(&tmp)[tmpLen.wrapping_sub(len) as usize..])[0usize..len as usize]
-  )
-}
-
-#[inline] pub fn Hacl_Bignum_Lib_bn_get_top_index_u32(len: u32, b: &[u32]) -> u32
-{
-  let mut r#priv: u32 = 0u32;
-  for i in 0u32..len
+  for i in aLen.wrapping_div(4u32).wrapping_mul(4u32)..aLen
   {
-    let mask: u32 = crate::hacl_krmllib::FStar_UInt32_eq_mask(b[i as usize], 0u32);
-    r#priv = mask & r#priv | ! mask & i
+    let t1: u64 = a[i as usize];
+    let t2: u64 = b[i as usize];
+    let res_i: (&mut [u64], &mut [u64]) = res.split_at_mut(i as usize);
+    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t2, res_i.1)
   };
-  return r#priv
-}
-
-#[inline] pub fn Hacl_Bignum_Lib_bn_get_top_index_u64(len: u32, b: &[u64]) -> u64
-{
-  let mut r#priv: u64 = 0u64;
-  for i in 0u32..len
-  {
-    let mask: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask(b[i as usize], 0u64);
-    r#priv = mask & r#priv | ! mask & i as u64
-  };
-  return r#priv
-}
-
-#[inline] pub fn Hacl_Bignum_Lib_bn_get_bits_u32(len: u32, b: &[u32], i: u32, l: u32) -> u32
-{
-  let i1: u32 = i.wrapping_div(32u32);
-  let j: u32 = i.wrapping_rem(32u32);
-  let p1: u32 = (b[i1 as usize]).wrapping_shr(j);
-  let mut ite: u32;
-  if i1.wrapping_add(1u32) < len && 0u32 < j
-  { ite = p1 | (b[i1.wrapping_add(1u32) as usize]).wrapping_shl(32u32.wrapping_sub(j)) }
-  else
-  { ite = p1 };
-  return ite & 1u32.wrapping_shl(l).wrapping_sub(1u32)
-}
-
-#[inline] pub fn Hacl_Bignum_Lib_bn_get_bits_u64(len: u32, b: &[u64], i: u32, l: u32) -> u64
-{
-  let i1: u32 = i.wrapping_div(64u32);
-  let j: u32 = i.wrapping_rem(64u32);
-  let p1: u64 = (b[i1 as usize]).wrapping_shr(j);
-  let mut ite: u64;
-  if i1.wrapping_add(1u32) < len && 0u32 < j
-  { ite = p1 | (b[i1.wrapping_add(1u32) as usize]).wrapping_shl(64u32.wrapping_sub(j)) }
-  else
-  { ite = p1 };
-  return ite & 1u64.wrapping_shl(l).wrapping_sub(1u64)
+  return c
 }
 
 #[inline] pub fn Hacl_Bignum_Addition_bn_sub_eq_len_u32(
@@ -198,80 +156,122 @@
   return c
 }
 
-#[inline] pub fn Hacl_Bignum_Addition_bn_add_eq_len_u32(
-  aLen: u32,
-  a: &[u32],
-  b: &[u32],
-  res: &mut [u32]
-) ->
+#[inline] pub fn Hacl_Bignum_Base_mul_wide_add2_u32(a: u32, b: u32, c_in: u32, out: &mut [u32]) ->
     u32
 {
-  let mut c: u32 = 0u32;
-  for i in 0u32..aLen.wrapping_div(4u32)
-  {
-    let t1: u32 = a[4u32.wrapping_mul(i) as usize];
-    let t20: u32 = b[4u32.wrapping_mul(i) as usize];
-    let res_i0: (&mut [u32], &mut [u32]) = res.split_at_mut(4u32.wrapping_mul(i) as usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u32(c, t1, t20, res_i0.1);
-    let t10: u32 = a[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
-    let t21: u32 = b[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
-    let res_i1: (&mut [u32], &mut [u32]) = res_i0.1.split_at_mut(1usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u32(c, t10, t21, res_i1.1);
-    let t11: u32 = a[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
-    let t22: u32 = b[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
-    let res_i2: (&mut [u32], &mut [u32]) = res_i1.1.split_at_mut(1usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u32(c, t11, t22, res_i2.1);
-    let t12: u32 = a[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
-    let t2: u32 = b[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
-    let res_i: (&mut [u32], &mut [u32]) = res_i2.1.split_at_mut(1usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u32(c, t12, t2, res_i.1)
-  };
-  for i in aLen.wrapping_div(4u32).wrapping_mul(4u32)..aLen
-  {
-    let t1: u32 = a[i as usize];
-    let t2: u32 = b[i as usize];
-    let res_i: (&mut [u32], &mut [u32]) = res.split_at_mut(i as usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u32(c, t1, t2, res_i.1)
-  };
-  return c
+  let out0: u32 = out[0usize];
+  let res: u64 =
+      (a as u64).wrapping_mul(b as u64).wrapping_add(c_in as u64).wrapping_add(out0 as u64);
+  out[0usize] = res as u32;
+  return res.wrapping_shr(32u32) as u32
 }
 
-#[inline] pub fn Hacl_Bignum_Addition_bn_add_eq_len_u64(
-  aLen: u32,
-  a: &[u64],
-  b: &[u64],
-  res: &mut [u64]
-) ->
+#[inline] pub fn Hacl_Bignum_Base_mul_wide_add2_u64(a: u64, b: u64, c_in: u64, out: &mut [u64]) ->
     u64
 {
-  let mut c: u64 = 0u64;
-  for i in 0u32..aLen.wrapping_div(4u32)
+  let out0: u64 = out[0usize];
+  let res: crate::types::FStar_UInt128_uint128 =
+      crate::hacl_krmllib::FStar_UInt128_add(
+        crate::hacl_krmllib::FStar_UInt128_add(
+          crate::hacl_krmllib::FStar_UInt128_mul_wide(a, b),
+          crate::hacl_krmllib::FStar_UInt128_uint64_to_uint128(c_in)
+        ),
+        crate::hacl_krmllib::FStar_UInt128_uint64_to_uint128(out0)
+      );
+  out[0usize] = crate::hacl_krmllib::FStar_UInt128_uint128_to_uint64(res);
+  return
+  crate::hacl_krmllib::FStar_UInt128_uint128_to_uint64(
+    crate::hacl_krmllib::FStar_UInt128_shift_right(res, 64u32)
+  )
+}
+
+#[inline] pub fn Hacl_Bignum_Convert_bn_from_bytes_be_uint64(
+  len: u32,
+  b: &[u8],
+  res: &mut [u64]
+)
+{
+  let bnLen: u32 = len.wrapping_sub(1u32).wrapping_div(8u32).wrapping_add(1u32);
+  let tmpLen: u32 = 8u32.wrapping_mul(bnLen);
+  let mut tmp: Box<[u8]> = vec![0u8; tmpLen as usize].into_boxed_slice();
+  ((&mut (&mut tmp)[tmpLen.wrapping_sub(len) as usize..])[0usize..len as usize]).copy_from_slice(
+    &b[0usize..len as usize]
+  );
+  for i in 0u32..bnLen
   {
-    let t1: u64 = a[4u32.wrapping_mul(i) as usize];
-    let t20: u64 = b[4u32.wrapping_mul(i) as usize];
-    let res_i0: (&mut [u64], &mut [u64]) = res.split_at_mut(4u32.wrapping_mul(i) as usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t20, res_i0.1);
-    let t10: u64 = a[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
-    let t21: u64 = b[4u32.wrapping_mul(i).wrapping_add(1u32) as usize];
-    let res_i1: (&mut [u64], &mut [u64]) = res_i0.1.split_at_mut(1usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u64(c, t10, t21, res_i1.1);
-    let t11: u64 = a[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
-    let t22: u64 = b[4u32.wrapping_mul(i).wrapping_add(2u32) as usize];
-    let res_i2: (&mut [u64], &mut [u64]) = res_i1.1.split_at_mut(1usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u64(c, t11, t22, res_i2.1);
-    let t12: u64 = a[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
-    let t2: u64 = b[4u32.wrapping_mul(i).wrapping_add(3u32) as usize];
-    let res_i: (&mut [u64], &mut [u64]) = res_i2.1.split_at_mut(1usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i.1)
-  };
-  for i in aLen.wrapping_div(4u32).wrapping_mul(4u32)..aLen
+    let u: u64 =
+        crate::lowstar_endianness::load64_be(
+          &(&tmp)[bnLen.wrapping_sub(i).wrapping_sub(1u32).wrapping_mul(8u32) as usize..]
+        );
+    let x: u64 = u;
+    let os: (&mut [u64], &mut [u64]) = res.split_at_mut(0usize);
+    os.1[i as usize] = x
+  }
+}
+
+#[inline] pub fn Hacl_Bignum_Convert_bn_to_bytes_be_uint64(len: u32, b: &[u64], res: &mut [u8])
+{
+  let bnLen: u32 = len.wrapping_sub(1u32).wrapping_div(8u32).wrapping_add(1u32);
+  let tmpLen: u32 = 8u32.wrapping_mul(bnLen);
+  let mut tmp: Box<[u8]> = vec![0u8; tmpLen as usize].into_boxed_slice();
+  for i in 0u32..bnLen
   {
-    let t1: u64 = a[i as usize];
-    let t2: u64 = b[i as usize];
-    let res_i: (&mut [u64], &mut [u64]) = res.split_at_mut(i as usize);
-    c = crate::lib_intrinsics::Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t2, res_i.1)
+    crate::lowstar_endianness::store64_be(
+      &mut (&mut tmp)[i.wrapping_mul(8u32) as usize..],
+      b[bnLen.wrapping_sub(i).wrapping_sub(1u32) as usize]
+    )
   };
-  return c
+  (res[0usize..len as usize]).copy_from_slice(
+    &(&(&tmp)[tmpLen.wrapping_sub(len) as usize..])[0usize..len as usize]
+  )
+}
+
+#[inline] pub fn Hacl_Bignum_Lib_bn_get_bits_u32(len: u32, b: &[u32], i: u32, l: u32) -> u32
+{
+  let i1: u32 = i.wrapping_div(32u32);
+  let j: u32 = i.wrapping_rem(32u32);
+  let p1: u32 = (b[i1 as usize]).wrapping_shr(j);
+  let mut ite: u32;
+  if i1.wrapping_add(1u32) < len && 0u32 < j
+  { ite = p1 | (b[i1.wrapping_add(1u32) as usize]).wrapping_shl(32u32.wrapping_sub(j)) }
+  else
+  { ite = p1 };
+  return ite & 1u32.wrapping_shl(l).wrapping_sub(1u32)
+}
+
+#[inline] pub fn Hacl_Bignum_Lib_bn_get_bits_u64(len: u32, b: &[u64], i: u32, l: u32) -> u64
+{
+  let i1: u32 = i.wrapping_div(64u32);
+  let j: u32 = i.wrapping_rem(64u32);
+  let p1: u64 = (b[i1 as usize]).wrapping_shr(j);
+  let mut ite: u64;
+  if i1.wrapping_add(1u32) < len && 0u32 < j
+  { ite = p1 | (b[i1.wrapping_add(1u32) as usize]).wrapping_shl(64u32.wrapping_sub(j)) }
+  else
+  { ite = p1 };
+  return ite & 1u64.wrapping_shl(l).wrapping_sub(1u64)
+}
+
+#[inline] pub fn Hacl_Bignum_Lib_bn_get_top_index_u32(len: u32, b: &[u32]) -> u32
+{
+  let mut r#priv: u32 = 0u32;
+  for i in 0u32..len
+  {
+    let mask: u32 = crate::hacl_krmllib::FStar_UInt32_eq_mask(b[i as usize], 0u32);
+    r#priv = mask & r#priv | ! mask & i
+  };
+  return r#priv
+}
+
+#[inline] pub fn Hacl_Bignum_Lib_bn_get_top_index_u64(len: u32, b: &[u64]) -> u64
+{
+  let mut r#priv: u64 = 0u64;
+  for i in 0u32..len
+  {
+    let mask: u64 = crate::hacl_krmllib::FStar_UInt64_eq_mask(b[i as usize], 0u64);
+    r#priv = mask & r#priv | ! mask & i as u64
+  };
+  return r#priv
 }
 
 #[inline] pub fn Hacl_Bignum_Multiplication_bn_mul_u32(


### PR DESCRIPTION
This was achieved by decomposing the top-level logic into small, composable passes that could then be lifted to operate on multiple files at once.