### PR TITLE
Add a CI target for the extracted symcrypt SHA3

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -15,10 +15,31 @@ jobs:
   check:
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v3
-      - name: Build and test
-        run: nix develop --command make test
+      - name: Clone scylla
+        uses: actions/checkout@v4
+        with:
+          path: scylla
+
+      - name: Clone symcrypt
+        uses: actions/checkout@v4
+        with:
+          repository: msprotz/SymCrypt
+          path: symcrypt
+          submodules: true
+
+      - name: Build symcrypt
+        working-directory: symcrypt
+        run: |
+          nix develop "$GITHUB_WORKSPACE/scylla" --command scripts/build.py cmake build --no-fips --no-asm --config Release
+
+      - name: Build and test scylla
+        working-directory: scylla
+        run: |
+          export SYMCRYPT_HOME=$GITHUB_WORKSPACE/symcrypt
+          nix develop --command make test
+
       - name: Check output
+        working-directory: scylla
         run: |
           # Check that there are no differences between the generated outputs
           # and the committed outputs.

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -26,6 +26,7 @@ jobs:
           repository: msprotz/SymCrypt
           path: symcrypt
           submodules: true
+          ref: protz/scylla
 
       - name: Build symcrypt
         working-directory: symcrypt

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ test/build
 lib/DataModel.ml
 *.o
 *.exe
+.sysroot

--- a/flake.nix
+++ b/flake.nix
@@ -171,7 +171,7 @@
       {
         devShells.default = (pkgs.mkShell.override { stdenv = llvmPackages.stdenv; }) {
           # Get backtrace on exception
-          OCAMLRUNPARAM = "b";
+          # OCAMLRUNPARAM = "b";
           # Unsure why adding these as `buildInputs` didn't work, but at least this works.
           C_INCLUDE_PATH = "${llvmPackages.clang}/resource-root/include:${pkgs.glibc.dev}/include";
 
@@ -184,6 +184,8 @@
 
           nativeBuildInputs = [
             rustToolchain
+            pkgs.python3
+            pkgs.cmake
 
             pkgs.ocamlPackages.dune_3
             pkgs.ocamlPackages.ocaml


### PR DESCRIPTION
@Nadrieril as discussed -- this requires a checkout of https://github.com/msprotz/SymCrypt/ at $(SYMCRYPT_HOME), and a successful build of it, most likely with `scripts/build.py cmake build --no-fips --no-asm`