### PR TITLE
Un-nixify the CI

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -17,4 +17,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build and test
-        run: nix flake check -L
+        run: nix develop --command make test
+      - name: Check output
+        run: |
+          # Check that there are no differences between the generated outputs
+          # and the committed outputs.
+          if git diff --exit-code --quiet out > /dev/null; then
+            echo "Ok: the regenerated files are the same as the checked out files"
+          else
+            echo "Error: the regenerated files differ from the checked out files"
+            git diff out
+            exit 1
+          fi

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,6 @@ build: lib/DataModel.ml
 	@ocamlfind list | grep -q krml || test -L lib/krml || echo "⚠️⚠️⚠️ krml not found; we suggest cd lib && ln -s path/to/karamel/lib krml"
 	dune build && ln -sf _build/default/bin/main.exe scylla
 
-# This target is removed in CI because CI builds `scylla` itself.
 scylla: build
 
 .PHONY: test

--- a/flake.lock
+++ b/flake.lock
@@ -1,20 +1,5 @@
 {
   "nodes": {
-    "crane": {
-      "locked": {
-        "lastModified": 1744386647,
-        "narHash": "sha256-DXwQEJllxpYeVOiSlBhQuGjfvkoGHTtILLYO2FvcyzQ=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "d02c1cdd7ec539699aa44e6ff912e15535969803",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -77,21 +62,6 @@
         "type": "github"
       }
     },
-    "nix-filter": {
-      "locked": {
-        "lastModified": 1731533336,
-        "narHash": "sha256-oRam5PS1vcrr5UPgALW0eo1m/5/pls27Z/pabHNy2Ms=",
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "rev": "f7653272fd234696ae94229839a99b73c9ab7de0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1743588408,
@@ -124,13 +94,11 @@
     },
     "root": {
       "inputs": {
-        "crane": "crane",
         "flake-utils": [
           "karamel",
           "flake-utils"
         ],
         "karamel": "karamel",
-        "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs_2",
         "rust-overlay": "rust-overlay"
       }


### PR DESCRIPTION
The CI is entirely in nix, which makes it have to replicate what the `Makefile` does. This makes it painful for non-nix experts to update it. I'll leave just enough nix to be able to run `make test` in CI directly.