### PR TITLE
Improve handling of case'ing on tagged enums

### DIFF
--- a/lib/ClangToAst.ml
+++ b/lib/ClangToAst.ml
@@ -1242,8 +1242,9 @@ let rec translate_stmt (env : env) (s : Clang.Ast.stmt_desc) : Krml.Ast.expr =
       assert (condition_variable = None);
 
       let cond = translate_expr env cond in
+
       (* TODO most likely adjust *)
-      let branches = translate_branches env body.desc in
+      let branches = translate_branches env cond.typ body.desc in
       with_type (thd3 (List.hd branches)).typ (EMatch (Unchecked, cond, branches))
   | Case _ -> failwith "case not encapsulated in a switch"
   | Default _ -> failwith "default not encapsulated in a switch"
@@ -1283,8 +1284,11 @@ let rec translate_stmt (env : env) (s : Clang.Ast.stmt_desc) : Krml.Ast.expr =
 (* Translate case and default statements inside a switch to a list of branches for
    structured pattern-matching.
    The original C branches must consist of a list of `case` statements, terminated by
-   a `default` statement *)
-and translate_branches (env : env) (s : stmt_desc) : Krml.Ast.branches =
+   a `default` statement.
+   [t] corresponds to the type of the expression we are pattern-matching on, to
+   direct the translation
+   *)
+and translate_branches (env : env) (t: typ) (s : stmt_desc) : Krml.Ast.branches =
   match s with
   | Compound [ { desc = Default body; _ } ] ->
       let body = translate_stmt env body.desc in
@@ -1293,7 +1297,7 @@ and translate_branches (env : env) (s : stmt_desc) : Krml.Ast.branches =
   | Compound ({ desc = Case { lhs; rhs; body }; _ } :: tl) ->
       (* Unsupported GCC extension *)
       assert (rhs = None);
-      let pat = translate_expr env lhs in
+      let pat = adjust (translate_expr env lhs) t in
       let body = translate_stmt env body.desc in
       (* We only support pattern-matching on constants here.
          This allows to translate switches corresponding to pattern
@@ -1303,7 +1307,7 @@ and translate_branches (env : env) (s : stmt_desc) : Krml.Ast.branches =
         | EConstant n -> [], Krml.Ast.with_type pat.typ (PConstant n), body
         | _ -> failwith "Only constant patterns supported"
       end
-      :: translate_branches env (Compound tl)
+      :: translate_branches env t (Compound tl)
   | _ -> failwith "Ill-formed switch branches: Expected a case or a default"
 
 let translate_param (p : parameter) : binder =


### PR DESCRIPTION
This PR relies on the recent addition of `adjust` to improve the translation of pattern-matching on tagged structs.

```C
#include <stdint.h>
#include <stdbool.h>

#define None 0
#define Some 1

typedef uint8_t tags;

typedef struct optional_s
{
  tags tag;
  uint32_t v;
}
optional;

void g() {
  optional block_state = ((optional){ .tag = Some, .v = 0U });
  tags tag = Some;
  switch (tag) {
    case None: return;
    case Some: return;
    default: return;
  }
}
```

`None`  and `Some` in the cases are seen as ints by clang, leading to a type mismatch with matching on `tag`, which has type uint8. This PR propagates the expected type of the scrutinee to adjust the type of the cases.