### PR TITLE
Simplify variable declarations immediately followed by their definition

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -106,7 +106,7 @@ Supported options:|}
   let files = Krml.Bundles.make_bundles files in
 
   let files = Krml.Simplify.sequence_to_let#visit_files () files in
-  let files = Scylla.Simplify.remove_addrof_index#visit_files () files in
+  let files = Scylla.Simplify.simplify files in
   (* To obtain correct visibility after bundling *)
   let files = Krml.Inlining.cross_call_analysis files in
 

--- a/lib/Simplify.ml
+++ b/lib/Simplify.ml
@@ -27,7 +27,7 @@ let inline_immediate_vardef =
       let e2 = self#visit_expr_w () e2 in
       match e1.node, e2.node with
       | EAny, ELet (_, { node = EAssign (var, e); _}, e3) when var.node = EBound 0 ->
-          ELet (b, e, Krml.DeBruijn.lift (-1) e3)
+          ELet (b, Krml.DeBruijn.lift (-1) e, Krml.DeBruijn.lift (-1) e3)
       (* More uncommon case, where the assignment is in terminal position *)
       | EAny, EAssign (var, e) when var.node = EBound 0 ->
           ELet (b, e, Krml.Helpers.eunit)

--- a/lib/Simplify.ml
+++ b/lib/Simplify.ml
@@ -11,3 +11,31 @@ let remove_addrof_index =
       | EBufRead (e1, e2) -> EBufSub (e1, e2)
       | _ -> EAddrOf e
   end
+
+
+let inline_immediate_vardef =
+  object (self)
+    inherit [_] map
+
+    (* let x = any;
+       x = e;
+       ----->
+       let x = e;
+    *)
+    method! visit_ELet _ b e1 e2 =
+      let e1 = self#visit_expr_w () e1 in
+      let e2 = self#visit_expr_w () e2 in
+      match e1.node, e2.node with
+      | EAny, ELet (_, { node = EAssign (var, e); _}, e3) when var.node = EBound 0 ->
+          ELet (b, e, Krml.DeBruijn.lift (-1) e3)
+      (* More uncommon case, where the assignment is in terminal position *)
+      | EAny, EAssign (var, e) when var.node = EBound 0 ->
+          ELet (b, e, Krml.Helpers.eunit)
+      | _ -> ELet (b, e1, e2)
+
+    end
+
+
+let simplify files =
+  let files = remove_addrof_index#visit_files () files in
+  inline_immediate_vardef#visit_files () files


### PR DESCRIPTION
This PR aims to reduce the need for `default` (which cannot be implemented for all types). To do so, it adds a micropass to rewrite patterns such as
```rust
let x = Default :: default ();
x = e;
```
into
```rust
let x = e;
```


