### PR TITLE
Run CI on all branches, except if prefixed by underscore

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -2,8 +2,7 @@ name: Build Scylla and run tests
 
 on:
   push:
-    branches:
-      - main
+    branches-ignore: [ '_**' ]
   pull_request:
 
 # Cancel previous versions of this job that are still running.


### PR DESCRIPTION
And not just on the main branch, or on pull_request.