### PR TITLE
Reconstruct tagged unions as ADTs

### DIFF
--- a/lib/Attributes.ml
+++ b/lib/Attributes.ml
@@ -19,6 +19,13 @@ let default_attr = "scylla_default"
    be translated to `Box`es instead of borrows *)
 let box_attr = "scylla_box"
 
+(* An attribute to specify that a tagged union should be translated
+   to a Rust algebraic data type. We assume that the corresponding struct
+   consists of an integer field (the tag), followed by the union, and that
+   the tag ranges from 0 to the number of constructor, and matches the
+   order of the union cases. *)
+let adt_attr = "scylla_adt"
+
 (* We check for the presence of the [opaque_attr] attribute. We require it to
    be exactly the annotation *)
 let has_opaque_attr' (attr : attribute) =
@@ -36,6 +43,15 @@ let has_box_attr' (attr : attribute) =
   | _ -> false
 
 let has_box_attr (attrs : attribute list) = List.exists has_box_attr' attrs
+
+(* We check for the presence of the [adt_attr] attribute. We require it
+   to be exactly the annotation *)
+let has_adt_attr' (attr : attribute) =
+  match attr.desc with
+  | Clang__.Attributes.Annotate s -> String.equal s.annotation adt_attr
+  | _ -> false
+
+let has_adt_attr (attrs : attribute list) = List.exists has_adt_attr' attrs
 
 let retrieve_mutability' (attr : attribute) =
   match attr.desc with

--- a/lib/ClangToAst.ml
+++ b/lib/ClangToAst.ml
@@ -1073,10 +1073,14 @@ let rec translate_expr (env : env) ?(must_return_value=false) (e : Clang.Ast.exp
 
               begin
               match snd branch with
-              | [(_id, (t, _))] ->
-                  (* TODO: Fix this. Should not be EBound, but retrieved in environment,
-                     and should be checked to be in the correct tagged union case *)
-                  Krml.Ast.with_type t (EBound 0)
+              | [_] ->
+                  let var = match base.node with | EBound n -> List.nth env.vars n | _ -> failwith "Tagged union access is only supported on a variable" in
+                  begin match !(fth4 var) with
+                  | Some { case; var } when case = f ->
+                      let e, _, _ = find_var env var in
+                      e
+                  | _ -> failwith "Tagged union variable is not in the correct case"
+                  end
               | _ -> failwith "More than one field in tagged union case"
               end
           | Some (lazy (Flat fields)) ->


### PR DESCRIPTION
This PR adds support for translating tagged unions to Rust ADTs, therefore supporting the code below.
Doing so requires the following:
* The type declaration of the tagged union must be annotated with the `scylla_adt` attribute.
* The tagged union type must consist of an integer field named `tag`, followed by the union.
* Tags are assumed to be numbered from 0 to N, with i representing the i-th element of the union (starting the count at 0).
* Pattern-matching on a tag is detected through branches of the shape `if x.tag == N ...`. In particular, switches are not supported, nor compound expressions for member access (`if e.tag == N ...` must be rewritten into `{type} x = e; if x.tag == N ...`).
* When branching on a tag through `if x.tag == i`, we translate it to a pattern-matching on the i-th constructor of the corresponding ADT, and store in the environment that `x` is in the i-th case of the union for the entirety of the if branch.
* Accessing a case of the union (e.g., `x.case_uint8` below) is only allowed if the variable is currently in the right union state according to the environment. Otherwise, an error is raised during the translation.


```c
#include <stdint.h>

#define Case1 0
#define Case2 1

typedef struct
__attribute__((annotate("scylla_adt")))
raw_s {
  uint8_t tag;
  union {
    uint8_t case_uint8;
    uint16_t case_uint16;
  }
  ;
} raw;


void f () {
  raw s = {.tag = Case1, { .case_uint8 = 0 }};
  if (s.tag == Case1) {
    uint8_t x = s.case_uint8;
  } else if (s.tag == Case2) {
    uint16_t x = s.case_uint16;
  }
}
```