### PR TITLE
Add support for tuples reconstruction

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -84,7 +84,8 @@ Supported options:|}
   let lib_dirs = get_sdkroot () @ Clang.default_include_directories () in
   let files = Scylla.ClangToAst.split_into_files lib_dirs deduped_files in
   Scylla.ClangToAst.fill_type_maps (if !Scylla.Options.ignore_lib_errors then lib_dirs else []) deduped_files;
-  let boxed_types, files = Scylla.ClangToAst.translate_compil_units files command_line_args in
+  let boxed_types, tuple_types, files = Scylla.ClangToAst.translate_compil_units files command_line_args in
+  let files = (Scylla.Simplify.inline_tuple_types tuple_types)#visit_files () files in
 
   let files = Krml.Builtin.lowstar_ignore :: files in
 

--- a/lib/Attributes.ml
+++ b/lib/Attributes.ml
@@ -33,6 +33,9 @@ let adt_attr = "scylla_adt"
    tagged union cases *)
 let empty_variant_attr = "scylla_empty_variant"
 
+(* Translate a given type to a tuple instead of a struct *)
+let tuple_attr = "scylla_tuple"
+
 (* Expose directly as a C FFI function or global, with #[no_mangle] and the like *)
 let expose_attr = "scylla_expose"
 
@@ -51,11 +54,13 @@ let has_opaque_attr = has opaque_attr
    be exactly the annotation *)
 let has_box_attr = has box_attr
 
-let has_expose_attr = has expose_attr
-
 (* We check for the presence of the [adt_attr] attribute. We require it
    to be exactly the annotation *)
 let has_adt_attr = has adt_attr
+
+let has_tuple_attr = has tuple_attr
+
+let has_expose_attr = has expose_attr
 
 (* If the [adt_attr] attribute is specified on a structure,
    we can also specify `scylla_empty_variant(name)`, which

--- a/lib/ClangToAst.ml
+++ b/lib/ClangToAst.ml
@@ -39,6 +39,10 @@ let elaborated_map = ref ElaboratedMap.empty
    that internal pointers should be translated to Boxes instead of borrows *)
 let boxed_types = ref LidSet.empty
 
+(* A map from types that are annotated with `scylla_tuple` to their
+   corresponding Ast tuple type definition. *)
+let tuple_types : typ LidMap.t ref = ref LidMap.empty
+
 (* The values of type_def_map below used to be of type lazy AST.type_def.
     However, when pattern-matching on lazy values, OCaml will force the evaluation,
     even if the resulting value does not correspond the pattern.
@@ -67,11 +71,13 @@ type type_def_lazy =
   | CAbbrev of Krml.Ast.typ Lazy.t
   | CEnum of (lident * Krml.Ast.z option) list Lazy.t
 
-let force_type_def_lazy (t: type_def_lazy) : Krml.Ast.type_def = match t with
+let force_type_def_lazy lid (t: type_def_lazy) : Krml.Ast.type_def = match t with
   | CVariant branches -> Variant (Lazy.force branches)
   | CFlat fields -> Flat (Lazy.force fields)
   | CTuple fields ->
-      Abbrev (TTuple (List.map (fun (_, (t, _)) -> t) (Lazy.force fields)))
+      let typ = TTuple (List.map (fun (_, (t, _)) -> t) (Lazy.force fields)) in
+      tuple_types := LidMap.add lid typ !tuple_types;
+      Abbrev typ
   | CAbbrev t -> Abbrev (Lazy.force t)
   | CEnum l -> Enum (Lazy.force l)
 
@@ -1962,7 +1968,7 @@ let translate_decl (decl : decl) =
       let lid = Option.get (lid_of_name name) in
       begin
         match LidMap.find_opt lid !type_def_map with
-        | Some def -> Some (DType (lid, [], 0, 0, force_type_def_lazy def))
+        | Some def -> Some (DType (lid, [], 0, 0, force_type_def_lazy lid def))
         | None -> None
       end
   | _ -> raise Unsupported
@@ -2224,7 +2230,7 @@ let fill_type_maps (ignored_dirs : string list) (decls: deduplicated_decls) =
 (* Final pass. Actually emit definitions. *)
 let translate_compil_units (ast : grouped_decls) (command_line_args : string list) =
   let file_args = List.map stem_of_file command_line_args in
-  !boxed_types, List.map (fun (file, decls) ->
+  !boxed_types, !tuple_types, List.map (fun (file, decls) ->
     if List.mem file file_args then
       file, List.filter_map translate_decl decls
     else

--- a/lib/ClangToAst.ml
+++ b/lib/ClangToAst.ml
@@ -399,6 +399,7 @@ let rec normalize_type t =
   | TBuf (t, c) -> TBuf (normalize_type t, c)
   | TArray (t, c) -> TArray (normalize_type t, c)
   | TArrow (t1, t2) -> TArrow (normalize_type t1, normalize_type t2)
+  | TTuple ts -> TTuple (List.map normalize_type ts)
   | _ -> t
 
 let translate_typ t = normalize_type (translate_typ t)

--- a/lib/ClangToAst.ml
+++ b/lib/ClangToAst.ml
@@ -1238,7 +1238,7 @@ and translate_fields env t es =
         let fields = Lazy.force lazy_fields in
         let field_names = List.map (fun x -> Option.get (fst x)) fields in
         if List.length field_names <> List.length es then
-          fatal_error "TODO: partial initializers (%s but %d initialiers)" (String.concat ", " field_names) (List.length es);
+          fatal_error "TODO: partial initializers (%s but %d initializers)" (String.concat ", " field_names) (List.length es);
         Krml.Ast.with_type t (EFlat (List.map2 (translate_field_expr env) es field_names))
     | CVariant lazy_branches ->
         let branches = Lazy.force lazy_branches in
@@ -1248,6 +1248,16 @@ and translate_fields env t es =
         | _ ->
           fatal_error "Expected two arguments for tagged union initializer";
         end
+
+    | CTuple lazy_fields ->
+        let fields = Lazy.force lazy_fields in
+        let field_names = List.map (fun x -> Option.get (fst x)) fields in
+        if List.length field_names <> List.length es then
+          fatal_error "TODO: partial initializers (%s but %d initializers)" (String.concat ", " field_names) (List.length es);
+        (* We go through translate_field_expr to ensure that the order of the
+           fields matches the initializers *)
+        let fields = List.map2 (translate_field_expr env) es field_names in
+        Krml.Ast.with_type t (ETuple (List.map snd fields))
 
     | _ -> failwith "impossible"
 

--- a/lib/Simplify.ml
+++ b/lib/Simplify.ml
@@ -57,6 +57,16 @@ let materialize_casts =
           super#visit_ECast env e t_to
   end
 
+let inline_tuple_types tuple_types =
+  object (_self)
+    inherit [_] map
+
+    method! visit_TQualified _ t =
+      match ClangToAst.LidMap.find_opt t tuple_types with
+      | Some t -> t
+      | None -> TQualified t
+  end
+
 let simplify files =
   let files = remove_addrof_index#visit_files () files in
   inline_immediate_vardef#visit_files () files


### PR DESCRIPTION
Several structs can be better translated as tuples, in particular to allow varying mutability on pointer fields.
This PR introduces a `scylla_tuple` attribute that can be added to struct definitions.

As an example, this allows translating the following C code
```c
#include <stdint.h>

typedef struct
__attribute__((annotate("scylla_tuple")))
a_s {
  uint8_t x;
  uint8_t y;
} a;

void f (void) {
  a s = { .x = 0, .y = 1 };
  uint8_t x = s.x;
}
```

into the following Rust code

```rust
pub type a = (u8, u8);

pub fn f()
{
  let s: (u8, u8) = (0u8,1u8);
  let x: u8 =
      {
        let v: u8 = s.0;
        v
      };
  ()
}
```

We need to preserve the C struct information throughout the translation to, e.g., map s.x into accessing the first element of the tuple. We therefore inline tuple type definitions as a follow-up simplification pass instead of doing it on the fly.
I also decided to keep the (unused) type declaration in the resulting Rust code to help mapping to the original code, but it could be easily removed as a further clean-up pass.