### PR TITLE
Reconstruct structs into slices

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -87,7 +87,10 @@ Supported options:|}
   let boxed_types, tuple_types, files = Scylla.ClangToAst.translate_compil_units files command_line_args in
   let files = (Scylla.Simplify.inline_tuple_types tuple_types)#visit_files () files in
 
-  let files = Krml.Builtin.lowstar_ignore :: files in
+  let pulse_builtin = "Pulse_Lib_Slice",
+    [ Krml.Builtin.mk_val ~nvars:1 [ "Pulse"; "Lib"; "Slice" ] "len" Krml.Ast.(TArrow (TBound 0, TInt SizeT)) ] in
+
+  let files = pulse_builtin :: Krml.Builtin.lowstar_ignore :: files in
 
   (* Makes debugging the checker messages horrible, otherwise *)
   let files = Krml.Simplify.let_to_sequence#visit_files () files in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -84,8 +84,9 @@ Supported options:|}
   let lib_dirs = get_sdkroot () @ Clang.default_include_directories () in
   let files = Scylla.ClangToAst.split_into_files lib_dirs deduped_files in
   Scylla.ClangToAst.fill_type_maps (if !Scylla.Options.ignore_lib_errors then lib_dirs else []) deduped_files;
-  let boxed_types, tuple_types, files = Scylla.ClangToAst.translate_compil_units files command_line_args in
-  let files = (Scylla.Simplify.inline_tuple_types tuple_types)#visit_files () files in
+  let boxed_types, files = Scylla.ClangToAst.translate_compil_units files command_line_args in
+  (* Needed to handle tuples and slices *)
+  let files = Krml.Inlining.inline_type_abbrevs files in
 
   let pulse_builtin = "Pulse_Lib_Slice",
     [ Krml.Builtin.mk_val ~nvars:1 [ "Pulse"; "Lib"; "Slice" ] "len" Krml.Ast.(TArrow (TBound 0, TInt SizeT)) ] in

--- a/lib/Attributes.ml
+++ b/lib/Attributes.ml
@@ -36,6 +36,11 @@ let empty_variant_attr = "scylla_empty_variant"
 (* Translate a given type to a tuple instead of a struct *)
 let tuple_attr = "scylla_tuple"
 
+(* Translate a struct type to a slice. It requires the
+   struct to have two fields, called `elt` and `len`,
+   where `elt` is a pointer type, and `len` is an integer *)
+let slice_attr = "scylla_slice"
+
 (* Expose directly as a C FFI function or global, with #[no_mangle] and the like *)
 let expose_attr = "scylla_expose"
 
@@ -59,6 +64,8 @@ let has_box_attr = has box_attr
 let has_adt_attr = has adt_attr
 
 let has_tuple_attr = has tuple_attr
+
+let has_slice_attr = has slice_attr
 
 let has_expose_attr = has expose_attr
 

--- a/lib/Simplify.ml
+++ b/lib/Simplify.ml
@@ -57,16 +57,6 @@ let materialize_casts =
           super#visit_ECast env e t_to
   end
 
-let inline_tuple_types tuple_types =
-  object (_self)
-    inherit [_] map
-
-    method! visit_TQualified _ t =
-      match ClangToAst.LidMap.find_opt t tuple_types with
-      | Some t -> t
-      | None -> TQualified t
-  end
-
 let simplify files =
   let files = remove_addrof_index#visit_files () files in
   inline_immediate_vardef#visit_files () files


### PR DESCRIPTION
This PR allows annotating struct types with a new `scylla_slice` attribute to recognize them as slices, and therefore translate them to a simple pointer.
The struct is expected to have exactly two fields called `elt` and `len`, with the first one being a pointer and the second being an int.
If x is a slice, calls to `x.elt` will be translated to `x` (as `x` will become a slice reference in Rust), and calls to `x.len` will be translated to the methodcall `x.len()`. To do so, we reuse existing infrastructure in karamel, and translate to the intermediate Pulse slice representation.

As an example, the following C program
```c
#include <stdint.h>
#include <stddef.h>

typedef struct
__attribute__((annotate("scylla_slice")))
a_s {
  uint8_t *elt;
  size_t len;
} a;

void f (a slice) {
  size_t x = slice.len;
  uint8_t* arr = slice.elt;
  a s = { .elt = NULL, .len = 0 };
  arr[0] = 1;
}
```

is now translated to
```rust

pub fn f(slice: &mut [u8])
{
  let x: usize = slice.len();
  let arr: &mut [u8] = slice;
  let s: &[u8] = &[];
  arr[0usize] = 1u8
}
```