### PR TITLE
Add support for container types

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -84,7 +84,7 @@ Supported options:|}
   let lib_dirs = get_sdkroot () @ Clang.default_include_directories () in
   let files = Scylla.ClangToAst.split_into_files lib_dirs deduped_files in
   Scylla.ClangToAst.fill_type_maps (if !Scylla.Options.ignore_lib_errors then lib_dirs else []) deduped_files;
-  let boxed_types, files = Scylla.ClangToAst.translate_compil_units files command_line_args in
+  let boxed_types, container_types, files = Scylla.ClangToAst.translate_compil_units files command_line_args in
   (* Needed to handle tuples and slices *)
   let files = Krml.Inlining.inline_type_abbrevs files in
 
@@ -128,6 +128,8 @@ Supported options:|}
 
   if Krml.Options.debug "AstOptim" then
     debug_ast files;
+
+  Krml.Options.contained := Scylla.ClangToAst.LidSet.elements container_types |> List.map snd;
 
   (* Addition of derives has to be done this way because we have a map from Ast lids to the derives
      we want, and if we try to do this after AstToMiniRust then we have Rust names that we do not

--- a/lib/Attributes.ml
+++ b/lib/Attributes.ml
@@ -179,3 +179,6 @@ let decl_is_opaque (decl : decl) =
 
 let decl_has_default decl =
   decl_has_attr decl default_attr
+
+let decl_is_container decl =
+  decl_has_attr decl container_attr

--- a/lib/Attributes.ml
+++ b/lib/Attributes.ml
@@ -44,6 +44,10 @@ let slice_attr = "scylla_slice"
 (* Expose directly as a C FFI function or global, with #[no_mangle] and the like *)
 let expose_attr = "scylla_expose"
 
+(* Recognize container types, i.e., structs that contain pointers to other pointers,
+   and that therefore need to be extracted with different lifetimes *)
+let container_attr = "scylla_container_type"
+
 let has a (attrs : attribute list) =
   List.exists (fun (attr: attribute) ->
     match attr.desc with
@@ -68,6 +72,8 @@ let has_tuple_attr = has tuple_attr
 let has_slice_attr = has slice_attr
 
 let has_expose_attr = has expose_attr
+
+let has_container_attr = has container_attr
 
 (* If the [adt_attr] attribute is specified on a structure,
    we can also specify `scylla_empty_variant(name)`, which


### PR DESCRIPTION
Propagating support from karamel for container types, this PR allows annotating type definitions with a new `scylla_container_type` attribute, which marks such type as a "container" for the Rust translation.