### PR TITLE
Minor Improvements to Rust tests

### DIFF
--- a/out/hacl/src/lib_intrinsics.rs
+++ b/out/hacl/src/lib_intrinsics.rs
@@ -22,22 +22,16 @@ pub fn Lib_IntTypes_Intrinsics_sub_borrow_u32(cin: u32, x: u32, y: u32, r: &mut 
 
 pub fn Lib_IntTypes_Intrinsics_add_carry_u64(cin: u64, x: u64, y: u64, r: &mut [u64]) -> u64
 {
-    let res: u64 = x.wrapping_add(cin).wrapping_add(y);
-    let c: u64 = (! crate::hacl_krmllib::FStar_UInt64_gte_mask(res, x) | crate::hacl_krmllib::FStar_UInt64_eq_mask(res, x) & cin) & 1u64;
-    r[0usize] = res;
+    let res: u128 = (x as u128).wrapping_add(cin as u128).wrapping_add(y as u128);
+    let c: u64 = res.wrapping_shr(64u32) as u64;
+    r[0usize] = res as u64;
     c
 }
 
 pub fn Lib_IntTypes_Intrinsics_sub_borrow_u64(cin: u64, x: u64, y: u64, r: &mut [u64]) -> u64
 {
-    let res: u64 = x.wrapping_sub(y).wrapping_sub(cin);
-    let c: u64 =
-        (crate::hacl_krmllib::FStar_UInt64_gte_mask(res, x) & ! crate::hacl_krmllib::FStar_UInt64_eq_mask(res, x)
-        |
-        crate::hacl_krmllib::FStar_UInt64_eq_mask(res, x) & cin)
-        &
-        1u64;
-    r[0usize] = res;
+    let res: u128 = (x as u128).wrapping_sub(y as u128).wrapping_sub(cin as u128);
+    let c: u64 = res.wrapping_shr(64u32) as u64 & 1u64;
+    r[0usize] = res as u64;
     c
 }
-

--- a/rs/lib_intrinsics.rs
+++ b/rs/lib_intrinsics.rs
@@ -22,22 +22,16 @@ pub fn Lib_IntTypes_Intrinsics_sub_borrow_u32(cin: u32, x: u32, y: u32, r: &mut 
 
 pub fn Lib_IntTypes_Intrinsics_add_carry_u64(cin: u64, x: u64, y: u64, r: &mut [u64]) -> u64
 {
-    let res: u64 = x.wrapping_add(cin).wrapping_add(y);
-    let c: u64 = (! crate::hacl_krmllib::FStar_UInt64_gte_mask(res, x) | crate::hacl_krmllib::FStar_UInt64_eq_mask(res, x) & cin) & 1u64;
-    r[0usize] = res;
+    let res: u128 = (x as u128).wrapping_add(cin as u128).wrapping_add(y as u128);
+    let c: u64 = res.wrapping_shr(64u32) as u64;
+    r[0usize] = res as u64;
     c
 }
 
 pub fn Lib_IntTypes_Intrinsics_sub_borrow_u64(cin: u64, x: u64, y: u64, r: &mut [u64]) -> u64
 {
-    let res: u64 = x.wrapping_sub(y).wrapping_sub(cin);
-    let c: u64 =
-        (crate::hacl_krmllib::FStar_UInt64_gte_mask(res, x) & ! crate::hacl_krmllib::FStar_UInt64_eq_mask(res, x)
-        |
-        crate::hacl_krmllib::FStar_UInt64_eq_mask(res, x) & cin)
-        &
-        1u64;
-    r[0usize] = res;
+    let res: u128 = (x as u128).wrapping_sub(y as u128).wrapping_sub(cin as u128);
+    let c: u64 = res.wrapping_shr(64u32) as u64 & 1u64;
+    r[0usize] = res as u64;
     c
 }
-

--- a/test/cbor/CBORDet.c
+++ b/test/cbor/CBORDet.c
@@ -2429,10 +2429,10 @@ static cbor_raw cbor_array_item(cbor_raw c, uint64_t i)
   }
   else
   {
-    // KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n",
-    //   __FILE__,
-    //   __LINE__,
-    //   "unreachable (pattern matches are exhaustive in F*)");
+    KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n",
+      __FILE__,
+      __LINE__,
+      "unreachable (pattern matches are exhaustive in F*)");
     KRML_HOST_EXIT(255U);
   }
 }
@@ -2478,10 +2478,10 @@ cbor_array_iterator_init(cbor_raw c)
   }
   else
   {
-    // KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n",
-    //   __FILE__,
-    //   __LINE__,
-    //   "unreachable (pattern matches are exhaustive in F*)");
+    KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n",
+      __FILE__,
+      __LINE__,
+      "unreachable (pattern matches are exhaustive in F*)");
     KRML_HOST_EXIT(255U);
   }
 }
@@ -2512,10 +2512,10 @@ cbor_array_iterator_is_empty(
   }
   else
   {
-    // KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n",
-    //   __FILE__,
-    //   __LINE__,
-    //   "unreachable (pattern matches are exhaustive in F*)");
+    KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n",
+      __FILE__,
+      __LINE__,
+      "unreachable (pattern matches are exhaustive in F*)");
     KRML_HOST_EXIT(255U);
   }
 }
@@ -2588,10 +2588,10 @@ cbor_array_iterator_next(
   }
   else
   {
-    // KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n",
-    //   __FILE__,
-    //   __LINE__,
-    //   "unreachable (pattern matches are exhaustive in F*)");
+    KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n",
+      __FILE__,
+      __LINE__,
+      "unreachable (pattern matches are exhaustive in F*)");
     KRML_HOST_EXIT(255U);
   }
 }
@@ -2638,10 +2638,10 @@ cbor_map_iterator_init(cbor_raw c)
   }
   else
   {
-    // KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n",
-    //   __FILE__,
-    //   __LINE__,
-    //   "unreachable (pattern matches are exhaustive in F*)");
+    KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n",
+      __FILE__,
+      __LINE__,
+      "unreachable (pattern matches are exhaustive in F*)");
     KRML_HOST_EXIT(255U);
   }
 }
@@ -2674,10 +2674,10 @@ cbor_map_iterator_is_empty(
   }
   else
   {
-    // KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n",
-    //   __FILE__,
-    //   __LINE__,
-    //   "unreachable (pattern matches are exhaustive in F*)");
+    KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n",
+      __FILE__,
+      __LINE__,
+      "unreachable (pattern matches are exhaustive in F*)");
     KRML_HOST_EXIT(255U);
   }
 }
@@ -2751,10 +2751,10 @@ cbor_map_iterator_next(
   }
   else
   {
-    // KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n",
-    //   __FILE__,
-    //   __LINE__,
-    //   "unreachable (pattern matches are exhaustive in F*)");
+    KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n",
+      __FILE__,
+      __LINE__,
+      "unreachable (pattern matches are exhaustive in F*)");
     KRML_HOST_EXIT(255U);
   }
 }
@@ -2797,10 +2797,10 @@ static uint8_t impl_major_type(cbor_raw x)
     return CBOR_MAJOR_TYPE_MAP;
   else
   {
-    // KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n",
-    //   __FILE__,
-    //   __LINE__,
-    //   "unreachable (pattern matches are exhaustive in F*)");
+    KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n",
+      __FILE__,
+      __LINE__,
+      "unreachable (pattern matches are exhaustive in F*)");
     KRML_HOST_EXIT(255U);
   }
 }
@@ -4184,10 +4184,10 @@ uint8_t cbor_det_read_simple_value(cbor_raw x)
     return x.case_CBOR_Case_Simple;
   else
   {
-    // KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n",
-    //   __FILE__,
-    //   __LINE__,
-    //   "unreachable (pattern matches are exhaustive in F*)");
+    KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n",
+      __FILE__,
+      __LINE__,
+      "unreachable (pattern matches are exhaustive in F*)");
     KRML_HOST_EXIT(255U);
   }
 }

--- a/test/cbor/krml/include/krml/internal/target.h
+++ b/test/cbor/krml/include/krml/internal/target.h
@@ -32,9 +32,9 @@
 #if (                                                                          \
     (defined __STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&             \
     (!(defined KRML_HOST_EPRINTF)))
-#  define KRML_HOST_EPRINTF(...) fprintf(stderr, __VA_ARGS__)
+#  define KRML_HOST_EPRINTF(...) // fprintf(stderr, __VA_ARGS__)
 #elif !(defined KRML_HOST_EPRINTF) && defined(_MSC_VER)
-#  define KRML_HOST_EPRINTF(...) fprintf(stderr, __VA_ARGS__)
+#  define KRML_HOST_EPRINTF(...) // fprintf(stderr, __VA_ARGS__)
 #endif
 
 #ifndef KRML_HOST_EXIT


### PR DESCRIPTION
* Use Rust native support for uint128 for add_carry_u64 and sub_borrow_u64
* Uncomment printf macros for cbor, by modifying the macro instead